### PR TITLE
feat: Initial structure and base files for MlThemeBuilder module

### DIFF
--- a/modules/mlthemebuilder/README.md
+++ b/modules/mlthemebuilder/README.md
@@ -1,0 +1,93 @@
+# MlThemeBuilder - Módulo Personalizador de Tema para Mundo Limpio (PrestaShop)
+
+**Autor:** Byron Briones
+**Sitio Web:** [bbrion.es](https://bbrion.es)
+**Versión:** 1.0.0
+**Compatible con PrestaShop:** 1.7.6+
+
+## Descripción
+
+**MlThemeBuilder** es un módulo para PrestaShop diseñado específicamente para la tienda "Mundo Limpio". Permite una personalización avanzada y modular de la apariencia del frontend, ofreciendo control sobre diversas secciones de la página de inicio y otros elementos del tema. El objetivo es proporcionar una herramienta flexible para que los administradores de la tienda puedan adaptar el diseño a sus necesidades sin requerir modificaciones directas de código en el tema.
+
+El módulo se centra en la facilidad de uso a través de un panel de administración intuitivo, permitiendo la gestión de contenido multiidioma, estilos globales y configuraciones específicas para cada sección.
+
+## Características Principales (Versión Inicial)
+
+*   **Gestión de Secciones Dinámicas:**
+    *   Secciones predefinidas para la página de inicio: Hero, Servicios, Productos, Banner CTA, Marcas, Ecología, Contacto, HTML Personalizado.
+    *   Sistema de arrastrar y soltar para reordenar las secciones.
+    *   Activación/desactivación individual de secciones.
+    *   Configuración detallada para cada tipo de sección (títulos, textos, imágenes, colores, layouts, etc.).
+*   **Personalización de Estilos Globales:**
+    *   Paleta de colores principal (primario, secundario, texto, enlaces, fondos).
+    *   Configuración de tipografía (fuentes principales y secundarias, tamaño base, escala de encabezados, enlace a Google Fonts).
+    *   Ajustes de layout (ancho máximo del contenedor, padding de secciones, radio de borde de botones).
+*   **Gestión de Contenido Específico:**
+    *   **Servicios:** Creación y gestión de elementos de servicio (icono, título, descripción) para ser mostrados en la sección de servicios.
+    *   **Marcas:** Administración de logos de marcas o socios (imagen, nombre, URL) para el slider de marcas.
+*   **Ajustes Avanzados:**
+    *   Inclusión de CSS personalizado.
+    *   Inclusión de JavaScript personalizado (en cabecera o pie de página).
+    *   Opciones para habilitar/deshabilitar animaciones CSS del módulo y carga diferida (lazy loading) de imágenes.
+    *   Soporte opcional para modo oscuro (mediante variables CSS y estilos).
+    *   Control de caché para las secciones renderizadas.
+*   **Importar/Exportar Configuración:**
+    *   Funcionalidad para exportar toda la configuración del módulo (estructura de secciones, contenido, estilos, etc.) a un archivo JSON.
+    *   Posibilidad de importar una configuración previamente exportada, con opciones de sobrescribir todo o fusionar/añadir.
+*   **Multiidioma y Multitienda (Básico):**
+    *   Campos de texto configurables por idioma.
+    *   Estructura de datos preparada para multitienda (aunque la lógica detallada de multitienda puede requerir mayor desarrollo según necesidades).
+*   **Panel de Administración Integrado:**
+    *   Controlador de administración dedicado con una interfaz clara dividida en pestañas para fácil acceso a todas las configuraciones.
+    *   Uso de AJAX para operaciones fluidas (reordenar, cambiar estado, guardar configuraciones de sección, etc.).
+
+## Estructura del Módulo
+
+El módulo sigue la estructura estándar de PrestaShop:
+
+```
+modules/mlthemebuilder/
+├── mlthemebuilder.php              # Archivo principal del módulo
+├── config.xml                      # Configuración del módulo
+├── README.md                       # Este archivo
+├── logo.png                        # Logo del módulo (pendiente)
+├── classes/                        # Clases ObjectModel (MlThemeSection, MlThemeService, etc.)
+├── controllers/admin/              # Controlador de administración (AdminMlThemeBuilderController)
+├── views/                          # Plantillas, CSS, JS, imágenes
+│   ├── css/                        # Archivos CSS (front.css, admin.css, animations.css)
+│   ├── js/                         # Archivos JavaScript (front.js, admin.js)
+│   ├── img/                        # Imágenes del módulo (iconos, fondos de sección, logos de marcas)
+│   └── templates/                  # Plantillas Smarty (.tpl)
+│       ├── admin/                  # Plantillas para el panel de administración
+│       └── hook/                   # Plantillas para los hooks del frontend
+├── translations/                   # Archivos de traducción (es.php, en.php)
+├── upgrade/                        # Scripts de actualización del módulo
+├── ajax/                           # Manejador de peticiones AJAX (si es necesario fuera del controlador)
+└── sql/                            # Archivos SQL para instalación y desinstalación
+```
+
+## Instalación
+
+1.  Comprimir la carpeta `mlthemebuilder` en un archivo ZIP.
+2.  Ir a Módulos > Catálogo de Módulos en el Back Office de PrestaShop.
+3.  Hacer clic en "Subir un módulo" y seleccionar el archivo ZIP.
+4.  Una vez subido, buscar "Mundo Limpio Theme Builder" en la lista de módulos e instalarlo.
+5.  Tras la instalación, aparecerá una nueva pestaña "Theme Builder" (o similar, según configuración del Tab) en el menú del Back Office (probablemente bajo "Mejorar" o "Diseño"), donde se podrá configurar el módulo.
+
+## Próximos Pasos (Desarrollo)
+
+*   Completar la implementación de todas las funcionalidades AJAX en `AdminMlThemeBuilderController.php`.
+*   Refinar las plantillas de configuración de cada sección en `views/templates/admin/sections/`.
+*   Asegurar que todas las opciones de configuración se guardan y cargan correctamente usando `MlThemeSetting.php` o `Configuration.php` de PrestaShop.
+*   Probar exhaustivamente la funcionalidad de importación/exportación.
+*   Desarrollar y probar los scripts de actualización (`upgrade/*.php`) a medida que se añadan nuevas versiones.
+*   Crear el `logo.png` para el módulo.
+*   Añadir más traducciones y completar las existentes.
+
+## Contribuciones
+
+Por el momento, este es un módulo desarrollado a medida para "Mundo Limpio". Para modificaciones o mejoras, contactar al autor.
+
+---
+
+Este `README.md` proporciona una visión general. Se actualizará a medida que el módulo evolucione.

--- a/modules/mlthemebuilder/ajax/ajax-mlthemebuilder.php
+++ b/modules/mlthemebuilder/ajax/ajax-mlthemebuilder.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * MlThemeBuilder AJAX Handler
+ */
+
+// Bootstrap PrestaShop
+require_once dirname(__FILE__) . '/../../../config/config.inc.php';
+require_once dirname(__FILE__) . '/../../../init.php'; // init.php will load ObjectModels
+
+// Security check: Ensure it's a valid AJAX request and user has permissions
+// This is a basic check; your AdminController would handle permissions more robustly for BO actions.
+if (!Tools::isSubmit('ajax') || !Tools::isSubmit('action') /* || !Context::getContext()->employee->isLoggedBack() */) {
+    die(json_encode(['error' => true, 'message' => 'Invalid AJAX request or permission denied.']));
+}
+
+// Ensure module is active
+$module = Module::getInstanceByName('mlthemebuilder');
+if (!$module || !$module->active) {
+    die(json_encode(['error' => true, 'message' => 'Module not active.']));
+}
+
+$action = Tools::getValue('action');
+$response = ['error' => true, 'message' => 'Unknown error.']; // Default response
+
+// --- Autoload classes if not done by init.php for some reason or for direct script access ---
+// spl_autoload_register(function ($class_name) {
+//     $file = _PS_MODULE_DIR_ . 'mlthemebuilder/classes/' . $class_name . '.php';
+//     if (file_exists($file)) {
+//         require_once $file;
+//     }
+// });
+
+// --- ACTION ROUTER ---
+// Note: For actions that modify data and are initiated from the BO,
+// it's best practice to handle them within an AdminController for security (tokens, permissions).
+// This AJAX handler might be more suitable for frontend AJAX calls or very specific, simple BO tasks
+// if an AdminController is not used for them.
+// The AdminMlThemeBuilderController already has many AJAX methods. This file might be redundant
+// or for different purposes (e.g., frontend AJAX).
+// Assuming this file is for general AJAX and might duplicate some BO logic if not careful.
+
+$context = Context::getContext();
+$id_shop = (int)$context->shop->id;
+$id_lang = (int)$context->language->id;
+
+switch ($action) {
+    // --- Section Actions (Example, mirror AdminController if needed) ---
+    case 'updateMlSectionOrder': // Renamed from updateSectionOrder
+        // This should ideally be in AdminMlThemeBuilderController with token check
+        $order = json_decode(Tools::getValue('order'), true);
+        if (is_array($order) && MlThemeSection::updatePositions($order)) {
+            $module->clearCache('*');
+            $response = ['success' => true, 'message' => $module->l('Section order updated.', 'ajax-mlthemebuilder')];
+        } else {
+            $response = ['error' => true, 'message' => $module->l('Failed to update section order.', 'ajax-mlthemebuilder')];
+        }
+        break;
+
+    case 'toggleMlSectionStatus': // Renamed
+        // Again, better in AdminController
+        $id_section = (int)Tools::getValue('id_mltheme_section');
+        $section = new MlThemeSection($id_section);
+        if (Validate::isLoadedObject($section)) {
+            $section->active = !$section->active;
+            if ($section->save()) {
+                $module->clearCache('*');
+                $response = ['success' => true, 'message' => $module->l('Section status updated.', 'ajax-mlthemebuilder'), 'active' => $section->active];
+            } else {
+                $response = ['error' => true, 'message' => $module->l('Failed to update section status.', 'ajax-mlthemebuilder')];
+            }
+        } else {
+            $response = ['error' => true, 'message' => $module->l('Section not found.', 'ajax-mlthemebuilder')];
+        }
+        break;
+
+    case 'saveMlSectionConfig': // Renamed
+        // Better in AdminController
+        $id_section = (int)Tools::getValue('id_mltheme_section');
+        $section = new MlThemeSection($id_section, null, $id_shop);
+        if (!Validate::isLoadedObject($section)) {
+             $response = ['error' => true, 'message' => $module->l('Section not found.', 'ajax-mlthemebuilder')];
+             break;
+        }
+
+        $config_data = Tools::getValue('config', []);
+        $titles = Tools::getValue('title');
+        $contents = Tools::getValue('content');
+        $button_texts = Tools::getValue('button_text');
+        $button_links = Tools::getValue('button_link');
+
+        $languages = Language::getLanguages(false);
+        foreach ($languages as $lang) {
+            $id_l = (int)$lang['id_lang'];
+            if (isset($titles[$id_l])) $section->title[$id_l] = $titles[$id_l];
+            if (isset($contents[$id_l])) $section->content[$id_l] = $contents[$id_l];
+            if (isset($button_texts[$id_l])) $section->button_text[$id_l] = $button_texts[$id_l];
+            if (isset($button_links[$id_l])) $section->button_link[$id_l] = $button_links[$id_l];
+        }
+        $section->config = json_encode($config_data);
+
+        if ($section->save()) {
+            $module->clearCache('*');
+            $response = ['success' => true, 'message' => $module->l('Configuration saved.', 'ajax-mlthemebuilder')];
+        } else {
+            $response = ['error' => true, 'message' => $module->l('Error saving configuration.', 'ajax-mlthemebuilder') . implode(', ', $section->getErrorMsg())];
+        }
+        break;
+
+    // --- Frontend Actions (Example: Contact Form) ---
+    case 'submitContactForm':
+        $contact_name = Tools::getValue('name');
+        $contact_email = Tools::getValue('email');
+        $contact_message = Tools::getValue('message');
+        $id_section_form = (int)Tools::getValue('id_section'); // To potentially get recipient from section config
+
+        if (!Validate::isGenericName($contact_name) || !Validate::isEmail($contact_email) || empty($contact_message)) {
+            $response = ['error' => true, 'message' => $module->l('Please fill all required fields correctly.', 'ajax-mlthemebuilder')];
+            break;
+        }
+
+        // Determine recipient email (e.g., from shop contact or section config)
+        $recipient_email = Configuration::get('PS_SHOP_EMAIL');
+        // $id_lang_mail = $context->language->id; // Or shop default language
+
+        // You might want to load section config to see if there's a specific recipient for this form
+        // if ($id_section_form) {
+        //     $section = new MlThemeSection($id_section_form, $id_lang, $id_shop);
+        //     if (Validate::isLoadedObject($section) && $section->config) {
+        //         $config = json_decode($section->config, true);
+        //         if (!empty($config['recipient_email_contact']) && Validate::isEmail($config['recipient_email_contact'])) {
+        //             $recipient_email = $config['recipient_email_contact'];
+        //         }
+        //     }
+        // }
+
+        $template_vars = array(
+            '{name}' => $contact_name,
+            '{email}' => $contact_email,
+            '{message}' => nl2br(Tools:: htmlentitiesUTF8($contact_message)), // nl2br for display in HTML email
+            '{shop_name}' => Configuration::get('PS_SHOP_NAME'),
+            '{shop_url}' => Context::getContext()->link->getPageLink('index', true, $id_lang)
+        );
+
+        $mail_subject = $module->l('New message from your website contact form', 'ajax-mlthemebuilder') . ' - ' . Configuration::get('PS_SHOP_NAME');
+
+        if (Mail::Send(
+            $id_lang, // id_lang, for template selection
+            'contact_form_submission', // template name (e.g., modules/mlthemebuilder/mails/es/contact_form_submission.html)
+            $mail_subject,
+            $template_vars,
+            $recipient_email, // To
+            null, // To Name
+            $contact_email, // From
+            $contact_name, // From Name
+            null, // FileAttachment
+            null, // SMTP
+            _PS_MODULE_DIR_ . $module->name . '/mails/' // Path to mail templates
+        )) {
+            $response = ['success' => true, 'message' => $module->l('Your message has been sent successfully!', 'ajax-mlthemebuilder')];
+        } else {
+            $response = ['error' => true, 'message' => $module->l('An error occurred while sending your message. Please try again later.', 'ajax-mlthemebuilder')];
+        }
+        break;
+
+    // --- Add other AJAX actions for Services, Brands, Settings as needed if not handled by AdminController ---
+    // These would mirror the ajaxProcess[ActionName] methods in AdminMlThemeBuilderController.
+    // It's generally better to centralize BO AJAX actions in the controller.
+    // This file is more appropriate if you have frontend AJAX needs.
+
+    default:
+        $response = ['error' => true, 'message' => $module->l('Invalid action specified.', 'ajax-mlthemebuilder')];
+        break;
+}
+
+// Output JSON response
+header('Content-Type: application/json');
+die(json_encode($response));

--- a/modules/mlthemebuilder/ajax/index.php
+++ b/modules/mlthemebuilder/ajax/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/mlthemebuilder/classes/MlThemeBrand.php
+++ b/modules/mlthemebuilder/classes/MlThemeBrand.php
@@ -1,0 +1,196 @@
+<?php
+
+class MlThemeBrand extends ObjectModel
+{
+    public $id_mltheme_brand; // Primary key
+    public $name;
+    public $logo; // Filename of the logo image
+    public $url;
+    public $position;
+    public $active = 1;
+    public $date_add;
+    public $date_upd;
+    public $id_shop; // For shop association if brands are shop-specific
+
+    public static $definition = array(
+        'table' => 'mltheme_brands', // Updated table name
+        'primary' => 'id_mltheme_brand', // Updated primary key
+        'fields' => array(
+            'name' => array('type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'required' => true, 'size' => 255),
+            'logo' => array('type' => self::TYPE_STRING, 'validate' => 'isCleanHtml', 'size' => 255, 'required' => false), // Filename, not path
+            'url' => array('type' => self::TYPE_STRING, 'validate' => 'isUrlOrEmpty', 'size' => 255, 'required' => false),
+            'position' => array('type' => self::TYPE_INT, 'validate' => 'isUnsignedInt'),
+            'active' => array('type' => self::TYPE_BOOL, 'validate' => 'isBool'),
+            'date_add' => array('type' => self::TYPE_DATE, 'validate' => 'isDate', 'copy_post' => false),
+            'date_upd' => array('type' => self::TYPE_DATE, 'validate' => 'isDate', 'copy_post' => false),
+            // 'id_shop' => array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true), // Uncomment if brands are shop-specific
+        ),
+        'orderBy' => array('position' => 'ASC'),
+    );
+
+    public function __construct($id = null, $id_lang = null, $id_shop = null)
+    {
+        // Shop::addTableAssociation(self::$definition['table'], array('type' => 'shop')); // If brands are shop-specific
+        parent::__construct($id, $id_lang, $id_shop);
+        // If not using multishop context for this ObjectModel directly, ensure id_shop is handled if needed.
+        // if (!$this->id_shop && $id_shop) {
+        //     $this->id_shop = $id_shop;
+        // } elseif (!$this->id_shop) {
+        //     $this->id_shop = Context::getContext()->shop->id;
+        // }
+    }
+
+    public static function isUrlOrEmpty($url_string)
+    {
+        if (empty($url_string)) {
+            return true;
+        }
+        return Validate::isAbsoluteUrl($url_string) || preg_match('/^(\/|#|mailto:|tel:)/', $url_string) || !preg_match('/[<>"\'\s]/', $url_string);
+    }
+
+    public function add($auto_date = true, $null_values = false)
+    {
+        // if (!$this->id_shop) $this->id_shop = Context::getContext()->shop->id; // Ensure shop ID
+        if ($this->position <= 0) {
+            $this->position = self::getHighestPosition($this->id_shop) + 1;
+        }
+        if ($auto_date) {
+            $this->date_add = date('Y-m-d H:i:s');
+            $this->date_upd = date('Y-m-d H:i:s');
+        }
+        return parent::add($auto_date, $null_values);
+    }
+
+    public function update($null_values = false)
+    {
+        $this->date_upd = date('Y-m-d H:i:s');
+        return parent::update($null_values);
+    }
+
+    public static function getHighestPosition($id_shop = null)
+    {
+        $id_shop = $id_shop ?? Context::getContext()->shop->id;
+        $sql = 'SELECT MAX(`position`) FROM `' . _DB_PREFIX_ . self::$definition['table'] . '`';
+        // If shop-specific: $sql .= ' WHERE `id_shop` = '.(int)$id_shop;
+        $position = DB::getInstance()->getValue($sql);
+        return (is_numeric($position)) ? (int)$position : -1;
+    }
+
+    /**
+     * Get active brands for a shop.
+     * @param int|null $id_shop
+     * @param int|null $limit
+     * @return array|false
+     */
+    public static function getActiveBrands($id_shop = null, $limit = null)
+    {
+        $id_shop = $id_shop ?? Context::getContext()->shop->id;
+        $sql = new DbQuery();
+        $sql->select('*');
+        $sql->from(self::$definition['table']);
+        $sql->where('active = 1');
+        // If shop-specific: $sql->where('id_shop = '.(int)$id_shop);
+        $sql->orderBy('position ASC');
+
+        if ($limit !== null && (int)$limit > 0) {
+            $sql->limit((int)$limit);
+        }
+
+        return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
+    }
+
+    /**
+     * Get all brands for a shop.
+     * @param bool|null $active
+     * @param int|null $id_shop
+     * @return array|false
+     */
+    public static function getBrands($active = null, $id_shop = null)
+    {
+        $id_shop = $id_shop ?? Context::getContext()->shop->id;
+        $sql = new DbQuery();
+        $sql->select('*');
+        $sql->from(self::$definition['table']);
+
+        if ($active !== null) {
+            $sql->where('active = ' . (int)$active);
+        }
+        // If shop-specific: $sql->where('id_shop = '.(int)$id_shop); // Add this if uncommented id_shop field
+        $sql->orderBy('position ASC');
+
+        return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
+    }
+
+    public function delete()
+    {
+        // Delete associated logo file
+        if ($this->logo) {
+            $logo_path = _PS_MODULE_DIR_ . 'mlthemebuilder/views/img/brands/' . $this->logo;
+            if (file_exists($logo_path)) {
+                @unlink($logo_path);
+            }
+        }
+        if (!parent::delete()) {
+            return false;
+        }
+        self::reorderPositions($this->id_shop);
+        return true;
+    }
+
+    /**
+     * Updates the positions of multiple brands.
+     * @param array $positions_data Array of arrays, each containing 'id' and 'position'.
+     * @return bool True on success, false on failure.
+     */
+    public static function updatePositions($positions_data)
+    {
+        if (!is_array($positions_data)) {
+            return false;
+        }
+        $db = Db::getInstance();
+        try {
+            foreach ($positions_data as $item) {
+                if (!isset($item['id']) || !isset($item['position'])) {
+                    continue;
+                }
+                $db->update(
+                    self::$definition['table'],
+                    array('position' => (int)$item['position'], 'date_upd' => date('Y-m-d H:i:s')),
+                    '`'.self::$definition['primary'].'` = ' . (int)$item['id']
+                    // If shop specific: . ' AND `id_shop` = ' . (int)Context::getContext()->shop->id
+                );
+            }
+        } catch (PrestaShopDatabaseException $e) {
+            PrestaShopLogger::addLog("MlThemeBrand::updatePositions Error: " . $e->getMessage());
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Reorders positions for all brands (e.g., after a delete).
+     * @param int|null $id_shop
+     * @return bool
+     */
+    public static function reorderPositions($id_shop = null)
+    {
+        $id_shop = $id_shop ?? Context::getContext()->shop->id;
+        $brands = self::getBrands(null, $id_shop);
+
+        $position = 1;
+        foreach ($brands as $brand_data) {
+            Db::getInstance()->update(
+                self::$definition['table'],
+                ['position' => $position++, 'date_upd' => date('Y-m-d H:i:s')],
+                '`'.self::$definition['primary'].'` = ' . (int)$brand_data[self::$definition['primary']]
+                // If shop specific: . ' AND `id_shop` = ' . (int)$id_shop
+            );
+        }
+        return true;
+    }
+
+    public function getErrorMsg()
+    {
+        return $this->errors;
+    }
+}

--- a/modules/mlthemebuilder/classes/MlThemeSection.php
+++ b/modules/mlthemebuilder/classes/MlThemeSection.php
@@ -1,0 +1,283 @@
+<?php
+
+class MlThemeSection extends ObjectModel
+{
+    public $id_mltheme_section; // Primary key
+    public $name; // Internal name (e.g., "hero_slider")
+    public $type; // Type of section (e.g., "hero", "products", "banner")
+    public $position;
+    public $active = 1;
+    public $config; // JSON string for specific section configurations
+    public $date_add;
+    public $date_upd;
+
+    // Multilingual fields
+    public $title;       // e.g., "Our Amazing Products"
+    public $content;     // e.g., "Check out this amazing selection..."
+    public $button_text; // e.g., "Shop Now"
+    public $button_link; // e.g., URL or route
+
+    public static $definition = array(
+        'table' => 'mltheme_sections', // Updated table name
+        'primary' => 'id_mltheme_section', // Updated primary key
+        'multilang' => true,
+        'multilang_shop' => true, // Data can be different per shop for multilingual fields
+        'fields' => array(
+            'name' => array('type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'required' => true, 'size' => 255, 'db_comment' => 'Internal name for identification'),
+            'type' => array('type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'required' => true, 'size' => 50, 'db_comment' => 'Type of section'),
+            'position' => array('type' => self::TYPE_INT, 'validate' => 'isUnsignedInt'),
+            'active' => array('type' => self::TYPE_BOOL, 'validate' => 'isBool'),
+            'config' => array('type' => self::TYPE_HTML, 'validate' => 'isJson', 'db_comment' => 'JSON configuration for the section'), // Stored as JSON
+            'date_add' => array('type' => self::TYPE_DATE, 'validate' => 'isDate', 'copy_post' => false),
+            'date_upd' => array('type' => self::TYPE_DATE, 'validate' => 'isDate', 'copy_post' => false),
+
+            // Multilang fields
+            'title' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isCleanHtml', 'size' => 255, 'required' => false),
+            'content' => array('type' => self::TYPE_HTML, 'lang' => true, 'validate' => 'isCleanHtml', 'required' => false), // Allow some HTML
+            'button_text' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isCleanHtml', 'size' => 100, 'required' => false),
+            'button_link' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isUrlOrEmpty', 'size' => 255, 'required' => false),
+        ),
+        'orderBy' => array('position' => 'ASC'),
+    );
+
+    public function __construct($id = null, $id_lang = null, $id_shop = null)
+    {
+        Shop::addTableAssociation(self::$definition['table'].'_lang', array('type' => 'fk_shop'));
+        parent::__construct($id, $id_lang, $id_shop);
+    }
+
+    // Custom validation method for URLs or empty strings, or simple relative paths
+    public static function isUrlOrEmpty($url)
+    {
+        if (empty($url)) {
+            return true;
+        }
+        // Allow absolute URLs, root-relative, page-relative, or anchor links
+        return Validate::isAbsoluteUrl($url) || preg_match('/^(\/|#|[a-zA-Z0-9_-]+)/', $url);
+    }
+
+    public function add($auto_date = true, $null_values = false)
+    {
+        if ($this->position <= 0) {
+            $this->position = self::getHighestPosition($this->id_shop ?? Context::getContext()->shop->id) + 1;
+        }
+        if ($auto_date) {
+            $this->date_add = date('Y-m-d H:i:s');
+            $this->date_upd = date('Y-m-d H:i:s');
+        }
+        return parent::add($auto_date, $null_values);
+    }
+
+    public function update($null_values = false)
+    {
+        $this->date_upd = date('Y-m-d H:i:s');
+        return parent::update($null_values);
+    }
+
+    public static function getHighestPosition($id_shop = null)
+    {
+        $id_shop = $id_shop ?? Context::getContext()->shop->id;
+        // Assuming sections are not shop specific in the main table, but lang table is.
+        // If sections are shop-specific, add a where clause for id_shop.
+        $sql = 'SELECT MAX(`position`) FROM `' . _DB_PREFIX_ . self::$definition['table'] . '`';
+        // If main table has id_shop: $sql .= ' WHERE `id_shop` = '.(int)$id_shop;
+        $position = DB::getInstance()->getValue($sql);
+        return (is_numeric($position)) ? (int)$position : -1;
+    }
+
+
+    /**
+     * Get all sections for a shop, ordered by position.
+     * @param bool|null $active Filter by active status
+     * @param int|null $id_lang Language ID
+     * @param int|null $id_shop Shop ID
+     * @return array|false
+     */
+    public static function getSections($active = null, $id_lang = null, $id_shop = null)
+    {
+        $context = Context::getContext();
+        $id_lang = $id_lang ?? (int)$context->language->id;
+        $id_shop = $id_shop ?? (int)$context->shop->id;
+
+        $sql = new DbQuery();
+        $sql->select('s.*, sl.*'); // Select all from both section and its lang table
+        $sql->from(self::$definition['table'], 's');
+        $sql->innerJoin(self::$definition['table'].'_lang', 'sl',
+            's.`'.self::$definition['primary'].'` = sl.`'.self::$definition['primary'].'`
+            AND sl.`id_lang` = ' . (int)$id_lang . ' AND sl.`id_shop` = ' . (int)$id_shop
+        );
+
+        if ($active !== null) {
+            $sql->where('s.active = ' . (int)$active);
+        }
+        // If sections are shop-specific in the main table 's':
+        // $sql->where('s.id_shop = '.(int)$id_shop);
+
+        $sql->orderBy('s.position ASC');
+
+        return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
+    }
+
+    /**
+     * Get sections by position, typically for front office display.
+     * @param bool|null $active
+     * @param int|null $id_lang
+     * @param int|null $id_shop
+     * @return array
+     */
+    public static function getSectionsByPosition($active = null, $id_lang = null, $id_shop = null)
+    {
+        // This method is essentially the same as getSections with current parameters.
+        // Kept for compatibility if specific logic was intended.
+        return self::getSections($active, $id_lang, $id_shop);
+    }
+
+
+    /**
+     * Updates the positions of multiple sections.
+     * @param array $positions Array of arrays, each containing 'id' and 'position'.
+     * @return bool True on success, false on failure.
+     */
+    public static function updatePositions($positions_data)
+    {
+        if (!is_array($positions_data)) {
+            return false;
+        }
+        $db = Db::getInstance();
+        try {
+            foreach ($positions_data as $item) {
+                if (!isset($item['id']) || !isset($item['position'])) {
+                    continue;
+                }
+                $db->update(
+                    self::$definition['table'],
+                    array('position' => (int)$item['position'], 'date_upd' => date('Y-m-d H:i:s')),
+                    '`'.self::$definition['primary'].'` = ' . (int)$item['id']
+                    // If sections are shop-specific, add shop ID to where clause:
+                    // . ' AND `id_shop` = ' . (int)Context::getContext()->shop->id
+                );
+            }
+        } catch (PrestaShopDatabaseException $e) {
+            PrestaShopLogger::addLog("MlThemeSection::updatePositions Error: " . $e->getMessage());
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Reorders positions for all sections (e.g., after a delete).
+     * @param int|null $id_shop
+     * @return bool
+     */
+    public static function reorderPositions($id_shop = null)
+    {
+        $id_shop = $id_shop ?? Context::getContext()->shop->id;
+        $sections = self::getSections(null, null, $id_shop); // Get all sections for the shop, ordered by position
+
+        $position = 1;
+        foreach ($sections as $section_data) {
+            Db::getInstance()->update(
+                self::$definition['table'],
+                ['position' => $position++, 'date_upd' => date('Y-m-d H:i:s')],
+                '`'.self::$definition['primary'].'` = ' . (int)$section_data[self::$definition['primary']]
+                // If shop specific in main table: . ' AND `id_shop` = ' . (int)$id_shop
+            );
+        }
+        return true;
+    }
+
+    /**
+     * Get a section ID by its internal name.
+     * @param string $name Internal name of the section.
+     * @param int|null $id_shop Shop ID.
+     * @return int|false Section ID or false if not found.
+     */
+    public static function getIdByName($name, $id_shop = null)
+    {
+        $id_shop = $id_shop ?? Context::getContext()->shop->id;
+        $sql = new DbQuery();
+        $sql->select('s.`'.self::$definition['primary'].'`');
+        $sql->from(self::$definition['table'], 's');
+        $sql->where('s.`name` = \'' . pSQL($name) . '\'');
+        // If sections are shop-specific in the main table 's':
+        // $sql->where('s.id_shop = '.(int)$id_shop);
+
+        return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
+    }
+
+
+    /**
+     * Deletes a section and its related data (lang entries).
+     * Also handles file deletions if config contains image paths.
+     * @return bool
+     */
+    public function delete()
+    {
+        // Example: Delete associated images if stored in module specific folders
+        // $config = json_decode($this->config, true);
+        // if ($config && isset($config['image_hero']) && $config['image_hero']) {
+        //     $image_path = _PS_MODULE_DIR_ . 'mlthemebuilder/views/img/sections/' . $config['image_hero'];
+        //     if (file_exists($image_path)) @unlink($image_path);
+        // }
+        // Similar for other image fields in config across section types.
+
+        if (!parent::delete()) {
+            return false;
+        }
+        // After successful delete, reorder positions
+        self::reorderPositions($this->id_shop);
+        return true;
+    }
+
+    /**
+     * Duplicates a section.
+     * @return MlThemeSection|false The new duplicated section object or false on failure.
+     */
+    public function duplicate()
+    {
+        $new_section = new MlThemeSection(null, null, $this->id_shop); // Use current object's shop context
+        foreach (self::$definition['fields'] as $field_name => $field_def) {
+            if (property_exists($this, $field_name) && $field_name != $this->def['primary']) {
+                 if ($field_name === 'active') {
+                    $new_section->$field_name = 0; // Duplicates are inactive by default
+                } elseif (isset($field_def['lang']) && $field_def['lang']) {
+                    // Copy multilingual fields for all languages
+                    foreach (Language::getIDs(false) as $id_lang) {
+                        if (isset($this->{$field_name}[$id_lang])) {
+                            $new_section->{$field_name}[$id_lang] = $this->{$field_name}[$id_lang];
+                        }
+                    }
+                } else {
+                    $new_section->$field_name = $this->$field_name;
+                }
+            }
+        }
+
+        // Modify name to indicate it's a copy
+        $new_section->name = $this->name . '_copy_' . time();
+        foreach (Language::getIDs(false) as $id_lang) {
+             if (isset($new_section->title[$id_lang])) {
+                $new_section->title[$id_lang] .= ' (' . MlThemeBuilder::getPsInstance()->l('Copy', 'AdminMlThemeBuilderController') . ')';
+             } else {
+                 $new_section->title[$id_lang] = $new_section->name . ' (' . MlThemeBuilder::getPsInstance()->l('Copy', 'AdminMlThemeBuilderController') . ')';
+             }
+        }
+
+        $new_section->position = self::getHighestPosition($this->id_shop) + 1;
+        // date_add and date_upd will be set by add() method
+
+        if ($new_section->add()) {
+            return $new_section;
+        }
+        return false;
+    }
+
+    /**
+     * Get error messages.
+     * @return array
+     */
+    public function getErrorMsg()
+    {
+        return $this->errors;
+    }
+}

--- a/modules/mlthemebuilder/classes/MlThemeService.php
+++ b/modules/mlthemebuilder/classes/MlThemeService.php
@@ -1,0 +1,195 @@
+<?php
+
+class MlThemeService extends ObjectModel
+{
+    public $id_mltheme_service; // Primary key
+    public $icon; // Class name for icon (e.g., "fa fa-truck") or path to image
+    public $position;
+    public $active = 1;
+    public $date_add;
+    public $date_upd;
+
+    // Multilingual fields
+    public $title;
+    public $description;
+    // public $link; // Optional: if services can link somewhere
+
+    public static $definition = array(
+        'table' => 'mltheme_services', // Updated table name
+        'primary' => 'id_mltheme_service', // Updated primary key
+        'multilang' => true,
+        'multilang_shop' => true,
+        'fields' => array(
+            'icon' => array('type' => self::TYPE_STRING, 'validate' => 'isCleanHtml', 'size' => 255, 'required' => false), // Allow HTML for SVG icons or class names
+            'position' => array('type' => self::TYPE_INT, 'validate' => 'isUnsignedInt'),
+            'active' => array('type' => self::TYPE_BOOL, 'validate' => 'isBool'),
+            'date_add' => array('type' => self::TYPE_DATE, 'validate' => 'isDate', 'copy_post' => false),
+            'date_upd' => array('type' => self::TYPE_DATE, 'validate' => 'isDate', 'copy_post' => false),
+
+            // Multilingual fields
+            'title' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'required' => true, 'size' => 255),
+            'description' => array('type' => self::TYPE_HTML, 'lang' => true, 'validate' => 'isCleanHtml', 'required' => false), // Allow some HTML
+            // 'link' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isUrlOrEmpty', 'size' => 255, 'required' => false),
+        ),
+        'orderBy' => array('position' => 'ASC'),
+    );
+
+    public function __construct($id = null, $id_lang = null, $id_shop = null)
+    {
+        Shop::addTableAssociation(self::$definition['table'].'_lang', array('type' => 'fk_shop'));
+        parent::__construct($id, $id_lang, $id_shop);
+    }
+
+    public function add($auto_date = true, $null_values = false)
+    {
+        if ($this->position <= 0) {
+            $this->position = self::getHighestPosition($this->id_shop ?? Context::getContext()->shop->id) + 1;
+        }
+        if ($auto_date) {
+            $this->date_add = date('Y-m-d H:i:s');
+            $this->date_upd = date('Y-m-d H:i:s');
+        }
+        return parent::add($auto_date, $null_values);
+    }
+
+    public function update($null_values = false)
+    {
+        $this->date_upd = date('Y-m-d H:i:s');
+        return parent::update($null_values);
+    }
+
+    public static function getHighestPosition($id_shop = null)
+    {
+        $id_shop = $id_shop ?? Context::getContext()->shop->id;
+        // Assuming services are not shop specific in main table. If they are, add id_shop to WHERE.
+        $sql = 'SELECT MAX(`position`) FROM `' . _DB_PREFIX_ . self::$definition['table'] . '`';
+        // If main table has id_shop: $sql .= ' WHERE `id_shop` = '.(int)$id_shop;
+        $position = DB::getInstance()->getValue($sql);
+        return (is_numeric($position)) ? (int)$position : -1;
+    }
+
+    /**
+     * Get active services for a given language and shop.
+     * @param int $id_lang
+     * @param int $id_shop
+     * @param int|null $limit
+     * @return array|false
+     */
+    public static function getActiveServices($id_lang, $id_shop, $limit = null)
+    {
+        $sql = new DbQuery();
+        $sql->select('s.*, sl.title, sl.description');
+        $sql->from(self::$definition['table'], 's');
+        $sql->innerJoin(self::$definition['table'].'_lang', 'sl',
+            's.`'.self::$definition['primary'].'` = sl.`'.self::$definition['primary'].'`
+            AND sl.`id_lang` = ' . (int)$id_lang . ' AND sl.`id_shop` = ' . (int)$id_shop
+        );
+        $sql->where('s.active = 1');
+        // If services are shop-specific in main table 's':
+        // $sql->where('s.id_shop = '.(int)$id_shop);
+        $sql->orderBy('s.position ASC');
+
+        if ($limit !== null && (int)$limit > 0) {
+            $sql->limit((int)$limit);
+        }
+
+        return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
+    }
+
+    /**
+     * Get all services for a shop.
+     * @param int|null $id_lang
+     * @param bool|null $active
+     * @param int|null $id_shop
+     * @return array|false
+     */
+    public static function getServices($id_lang = null, $active = null, $id_shop = null)
+    {
+        $context = Context::getContext();
+        $id_lang = $id_lang ?? (int)$context->language->id;
+        $id_shop = $id_shop ?? (int)$context->shop->id;
+
+        $sql = new DbQuery();
+        $sql->select('s.*, sl.*');
+        $sql->from(self::$definition['table'], 's');
+        $sql->innerJoin(self::$definition['table'].'_lang', 'sl',
+            's.`'.self::$definition['primary'].'` = sl.`'.self::$definition['primary'].'`
+            AND sl.`id_lang` = ' . (int)$id_lang . ' AND sl.`id_shop` = ' . (int)$id_shop
+        );
+
+        if ($active !== null) {
+            $sql->where('s.active = ' . (int)$active);
+        }
+        // If services are shop-specific in main table 's':
+        // $sql->where('s.id_shop = '.(int)$id_shop);
+        $sql->orderBy('s.position ASC');
+
+        return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
+    }
+
+    /**
+     * Updates the positions of multiple services.
+     * @param array $positions_data Array of arrays, each containing 'id' and 'position'.
+     * @return bool True on success, false on failure.
+     */
+    public static function updatePositions($positions_data)
+    {
+        if (!is_array($positions_data)) {
+            return false;
+        }
+        $db = Db::getInstance();
+        try {
+            foreach ($positions_data as $item) {
+                if (!isset($item['id']) || !isset($item['position'])) {
+                    continue;
+                }
+                $db->update(
+                    self::$definition['table'],
+                    array('position' => (int)$item['position'], 'date_upd' => date('Y-m-d H:i:s')),
+                    '`'.self::$definition['primary'].'` = ' . (int)$item['id']
+                    // If shop specific in main table: . ' AND `id_shop` = ' . (int)Context::getContext()->shop->id
+                );
+            }
+        } catch (PrestaShopDatabaseException $e) {
+             PrestaShopLogger::addLog("MlThemeService::updatePositions Error: " . $e->getMessage());
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Reorders positions for all services (e.g., after a delete).
+     * @param int|null $id_shop
+     * @return bool
+     */
+    public static function reorderPositions($id_shop = null)
+    {
+        $id_shop = $id_shop ?? Context::getContext()->shop->id;
+        $services = self::getServices(null, null, $id_shop);
+
+        $position = 1;
+        foreach ($services as $service_data) {
+            Db::getInstance()->update(
+                self::$definition['table'],
+                ['position' => $position++, 'date_upd' => date('Y-m-d H:i:s')],
+                '`'.self::$definition['primary'].'` = ' . (int)$service_data[self::$definition['primary']]
+                // If shop specific in main table: . ' AND `id_shop` = ' . (int)$id_shop
+            );
+        }
+        return true;
+    }
+
+    public function delete()
+    {
+        if (!parent::delete()) {
+            return false;
+        }
+        self::reorderPositions($this->id_shop);
+        return true;
+    }
+
+    public function getErrorMsg()
+    {
+        return $this->errors;
+    }
+}

--- a/modules/mlthemebuilder/classes/MlThemeSetting.php
+++ b/modules/mlthemebuilder/classes/MlThemeSetting.php
@@ -1,0 +1,172 @@
+<?php
+
+class MlThemeSetting extends ObjectModel
+{
+    public $id_mltheme_setting;
+    public $id_shop_group;
+    public $id_shop;
+    public $name;
+    public $value;
+    public $date_add;
+    public $date_upd;
+
+    public static $definition = array(
+        'table' => 'mltheme_settings',
+        'primary' => 'id_mltheme_setting',
+        'fields' => array(
+            'id_shop_group' => array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'allow_null' => true),
+            'id_shop' => array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'allow_null' => true),
+            'name' => array('type' => self::TYPE_STRING, 'validate' => 'isConfigName', 'required' => true, 'size' => 255),
+            'value' => array('type' => self::TYPE_HTML, 'validate' => 'isAnything', 'allow_null' => true), // Store as HTML/Text, JSON encode/decode in getter/setter if complex
+            'date_add' => array('type' => self::TYPE_DATE, 'validate' => 'isDate'),
+            'date_upd' => array('type' => self::TYPE_DATE, 'validate' => 'isDate'),
+        ),
+    );
+
+    /**
+     * Get a specific setting value.
+     *
+     * @param string $name Setting name
+     * @param int|null $id_shop Shop ID (null for current context)
+     * @param mixed $default Default value if not found
+     * @return mixed Setting value or default
+     */
+    public static function getSettingValue($name, $id_shop = null, $default = null)
+    {
+        if ($id_shop === null) {
+            $id_shop = Context::getContext()->shop->id;
+        }
+        $id_shop_group = Context::getContext()->shop->id_shop_group;
+
+        $sql = new DbQuery();
+        $sql->select('value');
+        $sql->from(self::$definition['table']);
+        $sql->where('name = \'' . pSQL($name) . '\'');
+        $sql->where('(`id_shop` = ' . (int)$id_shop . ' OR `id_shop` IS NULL OR `id_shop` = 0)'); // Shop specific or global for shop
+        $sql->where('(`id_shop_group` = ' . (int)$id_shop_group . ' OR `id_shop_group` IS NULL OR `id_shop_group` = 0)'); // Group specific or global for group
+        $sql->orderBy('`id_shop` DESC, `id_shop_group` DESC'); // Prioritize shop-specific, then group-specific
+
+        $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
+
+        if ($result === false) { // Db::getValue returns false if not found
+            return $default;
+        }
+
+        // Attempt to decode if it's JSON, otherwise return as is
+        $decoded = json_decode($result, true);
+        return (json_last_error() === JSON_ERROR_NONE) ? $decoded : $result;
+    }
+
+    /**
+     * Update or create a setting value.
+     *
+     * @param string $name Setting name
+     * @param mixed $value Setting value
+     * @param int|null $id_shop Shop ID (null for current context, 0 for all shops in group, specific ID for specific shop)
+     * @param int|null $id_shop_group Shop Group ID (null for current context, 0 for all groups)
+     * @return bool Success or failure
+     */
+    public static function updateSettingValue($name, $value, $id_shop = null, $id_shop_group = null)
+    {
+        if ($id_shop === null && Context::getContext()->shop->id) {
+            $id_shop = Context::getContext()->shop->id;
+        }
+        if ($id_shop_group === null && Context::getContext()->shop->id_shop_group) {
+            $id_shop_group = Context::getContext()->shop->id_shop_group;
+        }
+
+        // If $id_shop is 0, it means apply to all shops in the group (or all shops if group is also 0/null)
+        // If $id_shop is specific, $id_shop_group should ideally match or be the parent.
+
+        $setting_id = self::getSettingIdByName($name, $id_shop, $id_shop_group);
+
+        $setting = new MlThemeSetting($setting_id);
+        $setting->name = $name;
+
+        // If value is an array or object, JSON encode it
+        if (is_array($value) || is_object($value)) {
+            $setting->value = json_encode($value);
+        } else {
+            $setting->value = $value;
+        }
+
+        $setting->id_shop = (int)$id_shop; // Ensure it's int, 0 for global within group
+        $setting->id_shop_group = (int)$id_shop_group; // Ensure it's int, 0 for truly global
+
+        if ($setting_id) { // Update existing
+            return $setting->update();
+        } else { // Create new
+            $setting->date_add = date('Y-m-d H:i:s');
+            return $setting->add();
+        }
+    }
+
+    /**
+     * Get multiple settings.
+     * @param array $keys Array of setting names
+     * @param int|null $id_shop
+     * @param array $defaults Associative array of default values
+     * @return array Associative array of settings
+     */
+    public static function getMultipleSettings(array $keys, $id_shop = null, array $defaults = [])
+    {
+        $settings = [];
+        foreach ($keys as $key) {
+            $default_value = isset($defaults[$key]) ? $defaults[$key] : null;
+            // Try to infer boolean default for specific keys, otherwise null
+            if (in_array($key, ['enable_animations', 'enable_lazy_loading', 'enable_section_cache'])) {
+                $default_value = $defaults[$key] ?? true;
+            } elseif (in_array($key, ['enable_dark_mode'])) {
+                 $default_value = $defaults[$key] ?? false;
+            }
+            $settings[$key] = self::getSettingValue($key, $id_shop, $default_value);
+        }
+        return $settings;
+    }
+
+
+    /**
+     * Get the ID of a setting by its name and shop context.
+     * Helper function for updateSettingValue.
+     */
+    private static function getSettingIdByName($name, $id_shop = null, $id_shop_group = null)
+    {
+        $sql = new DbQuery();
+        $sql->select(self::$definition['primary']);
+        $sql->from(self::$definition['table']);
+        $sql->where('name = \'' . pSQL($name) . '\'');
+
+        if ($id_shop !== null) {
+            $sql->where('id_shop = ' . (int)$id_shop);
+        } else {
+            $sql->where('id_shop IS NULL OR id_shop = 0');
+        }
+
+        if ($id_shop_group !== null) {
+            $sql->where('id_shop_group = ' . (int)$id_shop_group);
+        } else {
+            $sql->where('id_shop_group IS NULL OR id_shop_group = 0');
+        }
+
+        return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
+    }
+
+    /**
+     * Delete a setting by name.
+     * @param string $name Setting name
+     * @param int|null $id_shop
+     * @param int|null $id_shop_group
+     * @return bool
+     */
+    public static function deleteSettingValue($name, $id_shop = null, $id_shop_group = null)
+    {
+        $where_clauses = ['name = \'' . pSQL($name) . '\''];
+        if ($id_shop !== null) {
+            $where_clauses[] = 'id_shop = ' . (int)$id_shop;
+        }
+        if ($id_shop_group !== null) {
+            $where_clauses[] = 'id_shop_group = ' . (int)$id_shop_group;
+        }
+        return Db::getInstance()->delete(self::$definition['table'], implode(' AND ', $where_clauses));
+    }
+}

--- a/modules/mlthemebuilder/classes/index.php
+++ b/modules/mlthemebuilder/classes/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/mlthemebuilder/config.xml
+++ b/modules/mlthemebuilder/config.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<module>
+    <name>mlthemebuilder</name>
+    <displayName><![CDATA[Mundo Limpio Theme Builder]]></displayName>
+    <version><![CDATA[1.0.0]]></version>
+    <description><![CDATA[Módulo para personalizar completamente el tema de tu tienda Mundo Limpio.]]></description>
+    <author><![CDATA[Byron Briones]]></author>
+    <author_uri><![CDATA[https://bbrion.es]]></author_uri>
+    <tab><![CDATA[front_office_features]]></tab>
+    <confirmUninstall><![CDATA[¿Estás seguro de que quieres desinstalar este módulo? Todos los datos de configuración se perderán.]]></confirmUninstall>
+    <is_configurable>1</is_configurable>
+    <need_instance>0</need_instance>
+    <ps_versions_compliancy>
+        <min><![CDATA[1.7.6]]></min>
+        <max><![CDATA[_PS_VERSION_]]></max>
+    </ps_versions_compliancy>
+    <limited_countries></limited_countries>
+    <module_key>a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4</module_key>
+</module>

--- a/modules/mlthemebuilder/controllers/admin/AdminMlThemeBuilderController.php
+++ b/modules/mlthemebuilder/controllers/admin/AdminMlThemeBuilderController.php
@@ -1,0 +1,907 @@
+<?php
+/**
+ * AdminMlThemeBuilderController
+ *
+ * This controller handles the configuration interface for the MlThemeBuilder module.
+ * It allows users to manage sections, customize their appearance, and handle other settings.
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class AdminMlThemeBuilderController extends ModuleAdminController
+{
+    protected $moduleInstance;
+
+    public function __construct()
+    {
+        $this->bootstrap = true;
+        $this->display = 'view'; // Use 'view' for custom template, 'list' for HelperList
+        $this->className = 'MlThemeSection'; // Main ObjectModel for sections
+        $this->table = MlThemeSection::$definition['table']; // Main table for sections, prefixed
+       // $this->identifier = MlThemeSection::$definition['primary']; // Primary key for sections
+
+        parent::__construct();
+        $this->moduleInstance = Module::getInstanceByName('mlthemebuilder');
+
+        // Check if module instance is valid
+        if (!$this->moduleInstance instanceof Module) {
+            // Handle error, e.g., redirect or display an error message
+            $this->errors[] = $this->trans('Module instance could not be loaded.', [], 'Modules.Mlthemebuilder.Admin');
+            // You might want to log this error as well.
+        }
+
+
+        $this->page_header_toolbar_title = $this->l('Mundo Limpio Theme Builder');
+        $this->toolbar_title = $this->l('Mundo Limpio Theme Builder Configuration');
+    }
+
+    /**
+     * Initialize the controller.
+     * Set up context, assign Smarty variables.
+     */
+    public function init()
+    {
+        parent::init();
+        // This is crucial if you are using a custom template for the entire page
+        // And not relying on HelperList or HelperForm for the main view.
+        // $this->content = $this->renderView(); // Calls renderView method
+    }
+
+    /**
+     * This method is called if $this->display = 'view';
+     * It should return the HTML content of your custom configuration page.
+     */
+    public function renderView()
+    {
+        if (!$this->moduleInstance) {
+             return '<div class="alert alert-danger">'.$this->trans('Module not loaded.', [], 'Modules.Mlthemebuilder.Admin').'</div>';
+        }
+        // Fetch all necessary data for the main configuration template
+        $id_lang = $this->context->language->id;
+        $id_shop = $this->context->shop->id;
+
+        // Sections for the manager
+        $sections = MlThemeSection::getSections(null, $id_lang, $id_shop);
+        $this->context->smarty->assign('sections', $sections);
+
+        // Services for the manager
+        $services_list = MlThemeService::getServices($id_lang, null, $id_shop); // Get all services
+        $this->context->smarty->assign('services_list', $services_list);
+
+        // Brands for the manager
+        $brands_list = MlThemeBrand::getBrands(null, $id_shop); // Get all brands
+        $this->context->smarty->assign('brands_list', $brands_list);
+
+        // Global Styles & Advanced Settings (from MlThemeSetting class)
+        $global_styles_keys = ['primary_color', 'secondary_color', 'text_color', 'link_color', 'bg_light_color', 'bg_dark_color', 'primary_font', 'secondary_font', 'base_font_size', 'heading_font_scale', 'google_fonts_url', 'container_max_width', 'section_padding_y', 'button_border_radius'];
+        $advanced_settings_keys = ['custom_css', 'custom_js_header', 'custom_js_footer', 'enable_animations', 'enable_lazy_loading', 'enable_dark_mode', 'enable_section_cache'];
+
+        $this->context->smarty->assign('global_styles', MlThemeSetting::getMultipleSettings($global_styles_keys, $id_shop));
+        $this->context->smarty->assign('advanced_settings', MlThemeSetting::getMultipleSettings($advanced_settings_keys, $id_shop));
+
+
+        // Other variables for the template
+        $this->context->smarty->assign(array(
+            'module_dir' => $this->moduleInstance->_path,
+            'module_local_path' => $this->moduleInstance->getLocalPath(),
+            'theme_img_path' => $this->moduleInstance->getModuleImgUri(), // Path to module's img dir for previews
+            'ajax_url' => $this->context->link->getAdminLink('AdminMlThemeBuilder', true, [], ['ajax' => 1]), // Generic AJAX URL
+            'img_upload_url' => $this->context->link->getAdminLink('AdminMlThemeBuilder', true, [], ['ajax' => 1, 'action' => 'UploadImage']), // Specific for image uploads
+            'export_config_url' => $this->context->link->getAdminLink('AdminMlThemeBuilder', true, [], ['action' => 'ExportConfig']),
+            'import_config_url' => $this->context->link->getAdminLink('AdminMlThemeBuilder', true, [], ['action' => 'ImportConfig']), // This will be handled by AJAX
+            'languages' => Language::getLanguages(false),
+            'default_language' => (int)Configuration::get('PS_LANG_DEFAULT'),
+            'current_language' => $this->context->language,
+            'ps_version' => _PS_VERSION_
+        ));
+
+        // Fetch the main configuration template
+        return $this->moduleInstance->display($this->moduleInstance->getLocalPath(), 'views/templates/admin/configure.tpl');
+    }
+
+    /**
+     * This is the entry point for actions when the page is loaded or a form is submitted.
+     * PrestaShop calls this method for POST requests.
+     */
+    public function postProcess()
+    {
+        if (Tools::isSubmit('submitMlThemeBuilderGlobal')) {
+            $this->processSaveGlobalSettings();
+        }
+        // Other specific form submissions can be handled here if not using AJAX
+        // For AJAX actions, they are typically handled in ajaxProcess[ActionName]() methods.
+
+        // Note: processSave() is typically for HelperForm submissions.
+        // If your global settings form is custom, you handle it manually.
+        parent::postProcess();
+    }
+
+    protected function processSaveGlobalSettings()
+    {
+        $id_shop_group = $this->context->shop->id_shop_group;
+        $id_shop = $this->context->shop->id;
+        $languages = Language::getLanguages(false);
+
+        // Save Global Styles
+        if (Tools::isSubmit('ctb_global_style')) { // Using 'ctb_' prefix from TPL for now
+            $global_styles = Tools::getValue('ctb_global_style');
+            if (is_array($global_styles)) {
+                foreach ($global_styles as $key => $value) {
+                    MlThemeSetting::updateSettingValue($key, $value, $id_shop);
+                }
+            }
+        }
+
+        // Save Advanced Settings
+        if (Tools::isSubmit('ctb_advanced_settings')) {
+            $advanced_settings = Tools::getValue('ctb_advanced_settings');
+             if (is_array($advanced_settings)) {
+                foreach ($advanced_settings as $key => $value) {
+                    // Sanitize boolean values from switches
+                    if (in_array($key, ['enable_animations', 'enable_lazy_loading', 'enable_dark_mode', 'enable_section_cache'])) {
+                        $value = (int)$value;
+                    }
+                    MlThemeSetting::updateSettingValue($key, $value, $id_shop);
+                }
+            }
+        }
+
+        // Clear module cache if settings affecting frontend are changed
+        $this->moduleInstance->clearCache('*');
+
+        $this->confirmations[] = $this->l('Global settings updated successfully.');
+    }
+
+
+    /**
+     * Handles AJAX requests.
+     * This method is called by PrestaShop when an AJAX request is made to this controller.
+     * The specific action is determined by Tools::getValue('action').
+     */
+    public function ajaxProcess()
+    {
+        $action = Tools::getValue('action');
+        // error_log("AdminMlThemeBuilderController AJAX action: " . $action); // For debugging
+
+        // Secure AJAX calls: check token if needed, check employee permissions
+        if (!$this->tabAccess['view']) {
+             $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Access denied.')]));
+        }
+
+        // Whitelist of allowed AJAX actions
+        $allowed_actions = [
+            'UpdateSectionOrder', 'ToggleSectionStatus', 'SaveSectionConfig', 'GetSectionForm', 'AddSection', 'DeleteSection',
+            'UpdateServiceOrder', 'ToggleServiceStatus', 'SaveService', 'GetService', 'DeleteService', 'GetUploadedIcons', 'UploadServiceIcon',
+            'UpdateBrandOrder', 'ToggleBrandStatus', 'SaveBrand', 'GetBrand', 'DeleteBrand', 'UploadBrandLogo', 'RemoveBrandLogo',
+            'UploadImage', // Generic image uploader for section configs
+            'ExportConfig', 'ImportConfig' // Import/Export actions
+        ];
+
+        if ($action && in_array($action, $allowed_actions) && method_exists($this, 'ajaxProcess' . $action)) {
+            return $this->{'ajaxProcess' . $action}();
+        } else {
+            $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Invalid AJAX action.') . $action]));
+        }
+    }
+
+    // --- Section AJAX Methods ---
+    public function ajaxProcessUpdateSectionOrder()
+    {
+        $orderData = Tools::getValue('order'); // Expecting an array of id_mltheme_section
+        if ($orderData && is_array($orderData)) {
+            $positions = [];
+            foreach ($orderData as $position => $id_section) {
+                // $id_section might be like "section_item_X" from some JS libs, extract X
+                if (is_string($id_section) && strpos($id_section, '_') !== false) {
+                     $id_parts = explode('_', $id_section);
+                     $id_section = (int)end($id_parts);
+                } else {
+                    $id_section = (int)$id_section;
+                }
+                if ($id_section > 0) {
+                    $positions[] = ['id' => $id_section, 'position' => $position + 1];
+                }
+            }
+            if (MlThemeSection::updatePositions($positions)) {
+                $this->moduleInstance->clearCache('*');
+                $this->ajaxDie(json_encode(['success' => true, 'message' => $this->l('Section order updated.')]));
+            }
+        }
+        $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Failed to update section order.')]));
+    }
+
+    public function ajaxProcessToggleSectionStatus()
+    {
+        $id_section = (int)Tools::getValue('id_mltheme_section');
+        if (!$id_section) {
+            $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Invalid section ID.')]));
+        }
+        $section = new MlThemeSection($id_section);
+        if (!Validate::isLoadedObject($section)) {
+            $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Section not found.')]));
+        }
+        $section->active = !$section->active;
+        if ($section->save()) {
+            $this->moduleInstance->clearCache('*');
+            $this->ajaxDie(json_encode(['success' => true, 'message' => $this->l('Section status updated.'), 'active' => $section->active]));
+        }
+        $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Failed to update section status.')]));
+    }
+
+    public function ajaxProcessAddSection()
+    {
+        $name = Tools::getValue('new_section_name');
+        $type = Tools::getValue('new_section_type');
+        $titles = Tools::getValue('new_section_title'); // Array by id_lang
+
+        if (empty($name) || !Validate::isGenericName($name)) {
+            $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Invalid section name.')]));
+        }
+        if (empty($type) || !Validate::isGenericName($type)) {
+            $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Invalid section type.')]));
+        }
+
+        $section = new MlThemeSection();
+        $section->name = $name;
+        $section->type = $type;
+        $section->active = 1; // Active by default
+        $section->config = '{}'; // Default empty JSON config
+
+        $languages = Language::getLanguages(false);
+        foreach ($languages as $lang) {
+            $id_lang = (int)$lang['id_lang'];
+            $section->title[$id_lang] = isset($titles[$id_lang]) ? $titles[$id_lang] : $name; // Default title to name if not provided
+            // Other multilingual fields can be defaulted here if needed
+        }
+
+        if ($section->add()) {
+            $this->moduleInstance->clearCache('*');
+            // Prepare data for the new row in template
+            $default_lang_id = (int)Configuration::get('PS_LANG_DEFAULT');
+            $display_name = $section->title[$default_lang_id] ?? $section->name;
+
+            $this->ajaxDie(json_encode([
+                'success' => true,
+                'message' => $this->l('Section added successfully.'),
+                'section' => [
+                    'id_mltheme_section' => $section->id,
+                    'name' => $section->name, // internal name
+                    'raw_name' => $section->name, // for template placeholder
+                    'display_name' => $display_name, // for template placeholder {name}
+                    'type' => $section->type,
+                    'position' => $section->position,
+                    'active' => $section->active,
+                ]
+            ]));
+        }
+        $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Failed to add section.') . implode(', ', $section->getErrorMsg())]));
+    }
+
+    public function ajaxProcessDeleteSection()
+    {
+        $id_section = (int)Tools::getValue('id_mltheme_section');
+        if (!$id_section) {
+            $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Invalid section ID.')]));
+        }
+        $section = new MlThemeSection($id_section);
+        if (!Validate::isLoadedObject($section)) {
+            $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Section not found.')]));
+        }
+        if ($section->delete()) {
+            $this->moduleInstance->clearCache('*');
+            // Also re-calculate positions for remaining sections if needed, though usually not required on simple delete.
+            MlThemeSection::reorderPositions($this->context->shop->id);
+            $this->ajaxDie(json_encode(['success' => true, 'message' => $this->l('Section deleted.')]));
+        }
+        $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Failed to delete section.')]));
+    }
+
+
+    public function ajaxProcessSaveSectionConfig()
+    {
+        $id_section = (int)Tools::getValue('id_mltheme_section');
+        if (!$id_section) {
+            $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Invalid Section ID')]));
+        }
+        $section = new MlThemeSection($id_section, null, $this->context->shop->id);
+        if (!Validate::isLoadedObject($section)) {
+            $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Section not found')]));
+        }
+
+        $config_data = Tools::getValue('config', []); // Expect an array of config fields
+        $titles = Tools::getValue('title'); // Array by id_lang
+        $contents = Tools::getValue('content'); // Array by id_lang
+        $button_texts = Tools::getValue('button_text'); // Array by id_lang
+        $button_links = Tools::getValue('button_link'); // Array by id_lang
+
+        $languages = Language::getLanguages(false);
+        foreach ($languages as $lang) {
+            $id_lang = (int)$lang['id_lang'];
+            if (isset($titles[$id_lang])) $section->title[$id_lang] = $titles[$id_lang];
+            if (isset($contents[$id_lang])) $section->content[$id_lang] = $contents[$id_lang]; // Make sure to use 'isCleanHTML' validation
+            if (isset($button_texts[$id_lang])) $section->button_text[$id_lang] = $button_texts[$id_lang];
+            if (isset($button_links[$id_lang])) $section->button_link[$id_lang] = $button_links[$id_lang];
+        }
+
+        // Sanitize config data before encoding, especially if it contains HTML or complex structures
+        // For example, if a 'custom_html' field is part of config:
+        // if (isset($config_data['custom_html_field'])) {
+        //     $config_data['custom_html_field'] = Tools::purifyHTML($config_data['custom_html_field']);
+        // }
+        $section->config = json_encode($config_data);
+        $section->date_upd = date('Y-m-d H:i:s');
+
+        if ($section->save()) {
+            $this->moduleInstance->clearCache('*');
+            $this->ajaxDie(json_encode(['success' => true, 'message' => $this->l('Configuration saved.')]));
+        } else {
+            $errors = $section->getErrorMsg();
+            $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Error saving configuration: ') . ($errors ? implode(', ', $errors) : '')]));
+        }
+    }
+
+    public function ajaxProcessGetSectionForm()
+    {
+        $id_section = (int)Tools::getValue('id_mltheme_section');
+        $section = new MlThemeSection($id_section, null, $this->context->shop->id); // Load for all languages initially
+
+        if (!Validate::isLoadedObject($section)) {
+            $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Section not found')]));
+        }
+
+        $config = json_decode($section->config, true);
+        if ($config === null) $config = [];
+
+        $languages = Language::getLanguages(false);
+        $section_data_for_tpl = [
+            'id_section' => $section->id,
+            'type' => $section->type,
+            'name' => $section->name,
+            'config' => $config,
+            'titles' => [], 'contents' => [], 'button_texts' => [], 'button_links' => [], // Initialize lang arrays
+        ];
+
+        foreach ($languages as $lang) {
+            $id_lang = (int)$lang['id_lang'];
+            // ObjectModel loads multilingual fields as arrays, access them directly
+            $section_data_for_tpl['titles'][$id_lang] = $section->title[$id_lang] ?? '';
+            $section_data_for_tpl['contents'][$id_lang] = $section->content[$id_lang] ?? '';
+            $section_data_for_tpl['button_texts'][$id_lang] = $section->button_text[$id_lang] ?? '';
+            $section_data_for_tpl['button_links'][$id_lang] = $section->button_link[$id_lang] ?? '';
+        }
+
+        $template_file = 'admin/sections/' . Tools::strtolower($section->type) . '.tpl';
+        $template_path_full = $this->moduleInstance->getLocalPath() . 'views/templates/' . $template_file;
+
+        if (!file_exists($template_path_full)) {
+             $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Config template not found for type:') . ' ' . $section->type]));
+        }
+
+        $this->context->smarty->assign(array(
+            'section_data' => $section_data_for_tpl,
+            'languages' => $languages,
+            'current_language' => $this->context->language, // Current BO language
+            'default_language' => (int)Configuration::get('PS_LANG_DEFAULT'),
+            'theme_img_path' => $this->moduleInstance->getModuleImgUri(), // For image previews
+            'module_local_path' => $this->moduleInstance->getLocalPath(), // For any server-side includes if necessary
+        ));
+
+        $form_html = $this->context->smarty->fetch($template_path_full);
+        $this->ajaxDie(json_encode(['success' => true, 'form_html' => $form_html, 'section_name' => $section_data_for_tpl['titles'][$this->context->language->id] ?? $section->name]));
+    }
+
+    // --- Service AJAX Methods ---
+    public function ajaxProcessUpdateServiceOrder() { /* ... similar to sections ... */
+        $orderData = Tools::getValue('order');
+        if ($orderData && is_array($orderData)) {
+            $positions = [];
+            foreach ($orderData as $position => $id_service_raw) {
+                 $id_service = (int)str_replace('service_item_', '', $id_service_raw);
+                if ($id_service > 0) {
+                    $positions[] = ['id' => $id_service, 'position' => $position + 1];
+                }
+            }
+            if (MlThemeService::updatePositions($positions)) {
+                $this->moduleInstance->clearCache('*');
+                $this->ajaxDie(json_encode(['success' => true, 'message' => $this->l('Service order updated.')]));
+            }
+        }
+        $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Failed to update service order.')]));
+    }
+    public function ajaxProcessToggleServiceStatus() { /* ... similar to sections ... */
+        $id_service = (int)Tools::getValue('id_mltheme_service');
+        $service = new MlThemeService($id_service);
+        if (!Validate::isLoadedObject($service)) $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Service not found.')]));
+        $service->active = !$service->active;
+        if ($service->save()) {
+            $this->moduleInstance->clearCache('*');
+            $this->ajaxDie(json_encode(['success' => true, 'message' => $this->l('Service status updated.'), 'active' => $service->active]));
+        }
+        $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Failed to update service status.')]));
+    }
+    public function ajaxProcessSaveService() { /* ... new object or load, populate, save ... */
+        $id_service = (int)Tools::getValue('id_mltheme_service');
+        $service = new MlThemeService($id_service ?: null, null, $this->context->shop->id);
+
+        $service->icon = Tools::getValue('icon');
+        $service->active = (int)Tools::getValue('active');
+
+        $languages = Language::getLanguages(false);
+        foreach ($languages as $lang) {
+            $id_lang = (int)$lang['id_lang'];
+            $service->title[$id_lang] = Tools::getValue('title_' . $id_lang);
+            $service->description[$id_lang] = Tools::getValue('description_' . $id_lang, ''); // Allow HTML, validate on model
+        }
+
+        if ($service->save()) {
+            $this->moduleInstance->clearCache('*');
+            $default_lang_id = (int)Configuration::get('PS_LANG_DEFAULT');
+            $this->ajaxDie(json_encode([
+                'success' => true,
+                'message' => $this->l('Service saved.'),
+                'service' => [
+                    'id_mltheme_service' => $service->id,
+                    'icon' => $service->icon,
+                    'title_default' => $service->title[$default_lang_id] ?? '',
+                    'active' => $service->active,
+                    // Pass all lang titles if needed for template update
+                     'titles' => $service->title,
+                ]
+            ]));
+        }
+        $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Failed to save service.') . implode(', ', $service->getErrorMsg())]));
+    }
+    public function ajaxProcessGetService() { /* ... load and return JSON data for form population ... */
+        $id_service = (int)Tools::getValue('id_mltheme_service');
+        $service = new MlThemeService($id_service, null, $this->context->shop->id);
+        if (!Validate::isLoadedObject($service)) $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Service not found.')]));
+
+        $data = (array)$service;
+        // Ensure multilingual fields are correctly formatted if not already arrays by ObjectModel
+        $data['title'] = $service->title;
+        $data['description'] = $service->description;
+
+        $this->ajaxDie(json_encode(['success' => true, 'service' => $data]));
+    }
+    public function ajaxProcessDeleteService() { /* ... load and delete ... */
+        $id_service = (int)Tools::getValue('id_mltheme_service');
+        $service = new MlThemeService($id_service);
+        if (!Validate::isLoadedObject($service)) $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Service not found.')]));
+        if ($service->delete()) {
+            $this->moduleInstance->clearCache('*');
+            MlThemeService::reorderPositions($this->context->shop->id);
+            $this->ajaxDie(json_encode(['success' => true, 'message' => $this->l('Service deleted.')]));
+        }
+        $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Failed to delete service.')]));
+    }
+    public function ajaxProcessGetUploadedIcons() { /* ... list files from img/icons ... */
+        $icons_dir = $this->moduleInstance->getLocalImgPath('icons');
+        $icons_uri = $this->moduleInstance->getModuleImgUri('icons');
+        $files = [];
+        if (is_dir($icons_dir)) {
+            $scanned_files = scandir($icons_dir);
+            foreach ($scanned_files as $file) {
+                if ($file !== '.' && $file !== '..' && $file !== 'index.php' && is_file($icons_dir . $file)) {
+                    if (preg_match('/\.(jpg|jpeg|png|gif|svg)$/i', $file)) {
+                        $files[] = ['name' => $file, 'url' => $icons_uri . $file];
+                    }
+                }
+            }
+        }
+        $this->ajaxDie(json_encode(['success' => true, 'icons' => $files]));
+    }
+    public function ajaxProcessUploadServiceIcon() { /* ... handle file upload to img/icons ... */
+        if (isset($_FILES['service_icon_file']) && $_FILES['service_icon_file']['error'] == 0) {
+            $uploader = new Uploader('service_icon_file');
+            $uploader->setAcceptTypes(['jpeg', 'jpg', 'png', 'gif', 'svg']);
+            $uploader->setSavePath($this->moduleInstance->getLocalImgPath('icons'));
+            $file = $uploader->process();
+
+            if ($file && !empty($file[0]) && $file[0]['status'] == 'ok') {
+                $this->ajaxDie(json_encode(['success' => true, 'message' => $this->l('Icon uploaded.'), 'filename' => $file[0]['name'], 'url' => $this->moduleInstance->getModuleImgUri('icons') . $file[0]['name']]));
+            } else {
+                $errors = $uploader->getErrors() ?: [$this->l('Unknown upload error.')];
+                $this->ajaxDie(json_encode(['error' => true, 'message' => implode(', ', $errors)]));
+            }
+        }
+        $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('No file uploaded or upload error.')]));
+    }
+
+
+    // --- Brand AJAX Methods ---
+    public function ajaxProcessUpdateBrandOrder() { /* ... similar to sections ... */
+        $orderData = Tools::getValue('order');
+        if ($orderData && is_array($orderData)) {
+            $positions = [];
+            foreach ($orderData as $position => $id_brand_raw) {
+                 $id_brand = (int)str_replace('brand_item_', '', $id_brand_raw); // Assuming JS sends IDs like 'brand_item_X'
+                if ($id_brand > 0) {
+                    $positions[] = ['id' => $id_brand, 'position' => $position + 1];
+                }
+            }
+            if (MlThemeBrand::updatePositions($positions)) {
+                $this->moduleInstance->clearCache('*');
+                $this->ajaxDie(json_encode(['success' => true, 'message' => $this->l('Brand order updated.')]));
+            }
+        }
+        $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Failed to update brand order.')]));
+    }
+    public function ajaxProcessToggleBrandStatus() { /* ... similar to sections ... */
+        $id_brand = (int)Tools::getValue('id_mltheme_brand');
+        $brand = new MlThemeBrand($id_brand);
+        if (!Validate::isLoadedObject($brand)) $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Brand not found.')]));
+        $brand->active = !$brand->active;
+        if ($brand->save()) {
+            $this->moduleInstance->clearCache('*');
+            $this->ajaxDie(json_encode(['success' => true, 'message' => $this->l('Brand status updated.'), 'active' => $brand->active]));
+        }
+        $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Failed to update brand status.')]));
+    }
+    public function ajaxProcessSaveBrand() { /* ... new object or load, populate, save, handle logo upload ... */
+        $id_brand = (int)Tools::getValue('id_mltheme_brand');
+        $brand = new MlThemeBrand($id_brand ?: null, null, $this->context->shop->id);
+
+        $brand->name = Tools::getValue('name');
+        $brand->url = Tools::getValue('url');
+        $brand->active = (int)Tools::getValue('active');
+        $current_logo = Tools::getValue('current_logo');
+
+        // Handle logo upload
+        if (isset($_FILES['logo_file']) && $_FILES['logo_file']['error'] == 0) {
+            $uploader = new Uploader('logo_file');
+            $uploader->setAcceptTypes(['jpeg', 'jpg', 'png', 'gif', 'svg']);
+            $uploader->setSavePath($this->moduleInstance->getLocalImgPath('brands'));
+            $file = $uploader->process($brand->name . '_' . time()); // Add timestamp to avoid overwrites
+
+            if ($file && !empty($file[0]) && $file[0]['status'] == 'ok') {
+                // Delete old logo if exists and different
+                if ($brand->logo && $brand->logo != $file[0]['name'] && file_exists($this->moduleInstance->getLocalImgPath('brands') . $brand->logo)) {
+                    @unlink($this->moduleInstance->getLocalImgPath('brands') . $brand->logo);
+                }
+                $brand->logo = $file[0]['name'];
+            } else {
+                $errors = $uploader->getErrors() ?: [$this->l('Logo upload error.')];
+                $this->ajaxDie(json_encode(['error' => true, 'message' => implode(', ', $errors)]));
+                return; // Stop processing if upload failed
+            }
+        } elseif ($current_logo) {
+            $brand->logo = $current_logo; // Keep current logo if no new one uploaded
+        } else {
+            // If current_logo is empty and no new file, it means remove logo.
+            // Delete old logo if it exists
+            if ($brand->logo && file_exists($this->moduleInstance->getLocalImgPath('brands') . $brand->logo)) {
+                @unlink($this->moduleInstance->getLocalImgPath('brands') . $brand->logo);
+            }
+            $brand->logo = null;
+        }
+
+
+        if ($brand->save()) {
+            $this->moduleInstance->clearCache('*');
+            $this->ajaxDie(json_encode([
+                'success' => true,
+                'message' => $this->l('Brand saved.'),
+                'brand' => [
+                    'id_mltheme_brand' => $brand->id,
+                    'name' => $brand->name,
+                    'logo' => $brand->logo,
+                    'logo_url' => $brand->logo ? $this->moduleInstance->getModuleImgUri('brands') . $brand->logo : null,
+                    'active' => $brand->active,
+                ]
+            ]));
+        }
+        $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Failed to save brand.') . implode(', ', $brand->getErrorMsg())]));
+    }
+    public function ajaxProcessGetBrand() { /* ... load and return JSON data for form population ... */
+        $id_brand = (int)Tools::getValue('id_mltheme_brand');
+        $brand = new MlThemeBrand($id_brand, null, $this->context->shop->id);
+        if (!Validate::isLoadedObject($brand)) $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Brand not found.')]));
+
+        $data = (array)$brand;
+        $data['logo_url'] = $brand->logo ? $this->moduleInstance->getModuleImgUri('brands') . $brand->logo : null;
+        $this->ajaxDie(json_encode(['success' => true, 'brand' => $data]));
+    }
+    public function ajaxProcessDeleteBrand() { /* ... load and delete, also delete logo file ... */
+        $id_brand = (int)Tools::getValue('id_mltheme_brand');
+        $brand = new MlThemeBrand($id_brand);
+        if (!Validate::isLoadedObject($brand)) $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Brand not found.')]));
+
+        // Delete logo file first
+        if ($brand->logo && file_exists($this->moduleInstance->getLocalImgPath('brands') . $brand->logo)) {
+            @unlink($this->moduleInstance->getLocalImgPath('brands') . $brand->logo);
+        }
+
+        if ($brand->delete()) {
+            $this->moduleInstance->clearCache('*');
+            MlThemeBrand::reorderPositions($this->context->shop->id);
+            $this->ajaxDie(json_encode(['success' => true, 'message' => $this->l('Brand deleted.')]));
+        }
+        $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Failed to delete brand.')]));
+    }
+     public function ajaxProcessRemoveBrandLogo() {
+        $id_brand = (int)Tools::getValue('id_mltheme_brand');
+        $brand = new MlThemeBrand($id_brand);
+        if (!Validate::isLoadedObject($brand)) {
+            $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Brand not found.')]));
+        }
+        if ($brand->logo && file_exists($this->moduleInstance->getLocalImgPath('brands') . $brand->logo)) {
+            @unlink($this->moduleInstance->getLocalImgPath('brands') . $brand->logo);
+        }
+        $brand->logo = null;
+        if ($brand->save()) {
+            $this->ajaxDie(json_encode(['success' => true, 'message' => $this->l('Logo removed.')]));
+        }
+        $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Failed to remove logo.')]));
+    }
+
+    // --- Generic Image Uploader for Section Configs ---
+    public function ajaxProcessUploadImage()
+    {
+        $upload_type = Tools::getValue('upload_type'); // e.g., 'section_background', 'section_image', 'icon'
+        $id_item = (int)Tools::getValue('id_item'); // e.g., id_section or other relevant ID
+        $destination_folder = '';
+
+        switch ($upload_type) {
+            case 'section_background':
+            case 'section_image':
+                $destination_folder = 'sections';
+                break;
+            case 'icon': // For generic icons if not using service/brand specific uploaders
+                $destination_folder = 'icons';
+                break;
+            default:
+                $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Invalid upload type.')]));
+        }
+
+        $save_path = $this->moduleInstance->getLocalImgPath($destination_folder);
+        if (!is_dir($save_path) || !is_writable($save_path)) {
+             @mkdir($save_path, 0775, true); // Try to create if not exists
+             if (!is_dir($save_path) || !is_writable($save_path)) {
+                $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Upload directory is not writable or does not exist: ') . $save_path]));
+             }
+        }
+
+        if (isset($_FILES['file']) && $_FILES['file']['error'] == 0) {
+            $uploader = new Uploader('file'); // Input name is 'file'
+            $uploader->setAcceptTypes(['jpeg', 'jpg', 'png', 'gif', 'svg', 'webp']);
+            $uploader->setSavePath($save_path);
+            // Generate a unique filename, perhaps prefixed by section ID or type
+            $original_name = pathinfo($_FILES['file']['name'], PATHINFO_FILENAME);
+            $extension = pathinfo($_FILES['file']['name'], PATHINFO_EXTENSION);
+            $filename_base = Tools::link_rewrite($original_name) . ($id_item ? '_'.$id_item : '');
+
+            $file = $uploader->process($filename_base . '_' . time() . '.' . $extension);
+
+            if ($file && !empty($file[0]) && $file[0]['status'] == 'ok') {
+                $this->ajaxDie(json_encode([
+                    'success' => true,
+                    'message' => $this->l('Image uploaded.'),
+                    'filename' => $file[0]['name'],
+                    'url' => $this->moduleInstance->getModuleImgUri($destination_folder) . $file[0]['name']
+                ]));
+            } else {
+                $errors = $uploader->getErrors() ?: [$this->l('Unknown upload error for image.')];
+                $this->ajaxDie(json_encode(['error' => true, 'message' => implode(', ', $errors)]));
+            }
+        }
+        $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('No file uploaded or general upload error.')]));
+    }
+
+    // --- Import/Export AJAX Methods ---
+    public function ajaxProcessExportConfig() {
+        // This might not be AJAX if it forces a file download directly.
+        // If it is AJAX, it would generate the file then provide a link.
+        // For simplicity, direct download is often handled outside typical AJAX flow.
+        // However, if triggering via JS, JS can construct the URL with selected parts.
+
+        $parts_to_export = Tools::getValue('parts'); // Comma-separated string like "sections_structure,global_styles"
+        if ($parts_to_export) {
+            $parts_array = explode(',', $parts_to_export);
+        } else {
+            // Default: export all
+            $parts_array = ['sections_structure', 'sections_content', 'services_data', 'brands_data', 'global_styles', 'advanced_settings'];
+        }
+
+        $export_data = [];
+        $id_lang_default = (int)Configuration::get('PS_LANG_DEFAULT');
+        $id_shop = (int)$this->context->shop->id;
+
+        if (in_array('sections_structure', $parts_array) || in_array('sections_content', $parts_array)) {
+            $sections = MlThemeSection::getSections(null, null, $id_shop); // Get all sections, all languages
+            $export_data['sections'] = [];
+            foreach ($sections as $s_db) {
+                $s_obj = new MlThemeSection($s_db['id_mltheme_section'], null, $id_shop);
+                $section_export = [
+                    'name' => $s_obj->name,
+                    'type' => $s_obj->type,
+                    'position' => $s_obj->position,
+                    'active' => $s_obj->active,
+                ];
+                if (in_array('sections_content', $parts_array)) {
+                    $section_export['config'] = json_decode($s_obj->config, true) ?: new stdClass(); // Ensure object if empty
+                    $section_export['titles'] = $s_obj->title;
+                    $section_export['contents'] = $s_obj->content;
+                    $section_export['button_texts'] = $s_obj->button_text;
+                    $section_export['button_links'] = $s_obj->button_link;
+                }
+                $export_data['sections'][] = $section_export;
+            }
+        }
+
+        if (in_array('services_data', $parts_array)) {
+            $services = MlThemeService::getServices(null, null, $id_shop); // All services, all langs
+            $export_data['services'] = [];
+            foreach ($services as $s_db) {
+                $s_obj = new MlThemeService($s_db['id_mltheme_service'], null, $id_shop);
+                $export_data['services'][] = [
+                    'icon' => $s_obj->icon,
+                    'position' => $s_obj->position,
+                    'active' => $s_obj->active,
+                    'titles' => $s_obj->title,
+                    'descriptions' => $s_obj->description,
+                ];
+            }
+        }
+
+        if (in_array('brands_data', $parts_array)) {
+             $brands = MlThemeBrand::getBrands(null, $id_shop); // All brands
+             $export_data['brands'] = [];
+             foreach ($brands as $b_db) {
+                 $export_data['brands'][] = [
+                     'name' => $b_db['name'],
+                     'logo' => $b_db['logo'], // Filename only
+                     'url' => $b_db['url'],
+                     'position' => $b_db['position'],
+                     'active' => $b_db['active'],
+                 ];
+             }
+        }
+
+        if (in_array('global_styles', $parts_array)) {
+            $keys = ['primary_color', 'secondary_color', 'text_color', 'link_color', 'bg_light_color', 'bg_dark_color', 'primary_font', 'secondary_font', 'base_font_size', 'heading_font_scale', 'google_fonts_url', 'container_max_width', 'section_padding_y', 'button_border_radius'];
+            $export_data['global_styles'] = MlThemeSetting::getMultipleSettings($keys, $id_shop);
+        }
+
+        if (in_array('advanced_settings', $parts_array)) {
+            $keys = ['custom_css', 'custom_js_header', 'custom_js_footer', 'enable_animations', 'enable_lazy_loading', 'enable_dark_mode', 'enable_section_cache'];
+            $export_data['advanced_settings'] = MlThemeSetting::getMultipleSettings($keys, $id_shop);
+        }
+
+        $filename = 'mlthemebuilder_config_' . date('Ymd_His') . '.json';
+        header('Content-Disposition: attachment; filename="' . $filename . '"');
+        header('Content-Type: application/json');
+        // No die() or exit() here if called from non-AJAX context to allow download.
+        // If this is truly an AJAX endpoint that returns JSON to trigger download on client:
+        // $this->ajaxDie(json_encode($export_data));
+        // For direct download from a link:
+        echo json_encode($export_data, JSON_PRETTY_PRINT);
+        exit;
+    }
+
+    public function ajaxProcessImportConfig() {
+        if (!isset($_FILES['import_file']) || $_FILES['import_file']['error'] != 0) {
+            $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('No file uploaded or upload error.')]));
+        }
+
+        $json_content = Tools::file_get_contents($_FILES['import_file']['tmp_name']);
+        $data = json_decode($json_content, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Invalid JSON file: ') . json_last_error_msg()]));
+        }
+
+        $import_mode = Tools::getValue('import_mode', 'overwrite_all'); // overwrite_all, merge_append
+        // $skip_uploads = (bool)Tools::getValue('import_skip_uploads', false); // Not implemented in detail here
+
+        $id_shop = (int)$this->context->shop->id;
+        $languages = Language::getLanguages(false);
+        $default_lang_id = (int)Configuration::get('PS_LANG_DEFAULT');
+        $errors = [];
+
+        Db::getInstance()->beginTransaction();
+
+        try {
+            // Global Styles
+            if (isset($data['global_styles']) && is_array($data['global_styles'])) {
+                if ($import_mode == 'overwrite_all') { /* Consider deleting existing first if necessary */ }
+                foreach ($data['global_styles'] as $key => $value) {
+                    MlThemeSetting::updateSettingValue($key, $value, $id_shop);
+                }
+            }
+            // Advanced Settings
+            if (isset($data['advanced_settings']) && is_array($data['advanced_settings'])) {
+                 if ($import_mode == 'overwrite_all') { /* Consider deleting existing first */ }
+                foreach ($data['advanced_settings'] as $key => $value) {
+                    MlThemeSetting::updateSettingValue($key, $value, $id_shop);
+                }
+            }
+
+            // Sections
+            if (isset($data['sections']) && is_array($data['sections'])) {
+                if ($import_mode == 'overwrite_all') {
+                    Db::getInstance()->execute('DELETE FROM `'._DB_PREFIX_.'mltheme_sections_lang` WHERE id_shop = '.$id_shop);
+                    Db::getInstance()->execute('DELETE FROM `'._DB_PREFIX_.'mltheme_sections`'); // Assuming sections are not shop-specific in main table or add shop condition
+                     // Reset auto_increment if needed, though usually not critical for this type of import
+                }
+                foreach ($data['sections'] as $s_data) {
+                    $section = null;
+                    if ($import_mode == 'merge_append') { // Try to find existing by name
+                        $existing_id = MlThemeSection::getIdByName($s_data['name'], $id_shop);
+                        if ($existing_id) $section = new MlThemeSection($existing_id, null, $id_shop);
+                    }
+                    if (!$section) $section = new MlThemeSection(null, null, $id_shop);
+
+                    $section->name = $s_data['name'];
+                    $section->type = $s_data['type'];
+                    $section->position = $s_data['position'];
+                    $section->active = $s_data['active'];
+                    $section->config = isset($s_data['config']) ? json_encode($s_data['config']) : '{}';
+
+                    foreach ($languages as $lang) {
+                        $id_l = (int)$lang['id_lang'];
+                        $iso = $lang['iso_code'];
+                        $section->title[$id_l] = $s_data['titles'][$iso] ?? $s_data['titles'][$id_l] ?? $s_data['titles'][$default_lang_id] ?? $s_data['name'];
+                        $section->content[$id_l] = $s_data['contents'][$iso] ?? $s_data['contents'][$id_l] ?? $s_data['contents'][$default_lang_id] ?? '';
+                        $section->button_text[$id_l] = $s_data['button_texts'][$iso] ?? $s_data['button_texts'][$id_l] ?? $s_data['button_texts'][$default_lang_id] ?? '';
+                        $section->button_link[$id_l] = $s_data['button_links'][$iso] ?? $s_data['button_links'][$id_l] ?? $s_data['button_links'][$default_lang_id] ?? '#';
+                    }
+                    if (!$section->save()) $errors[] = $this->l('Error saving section ') . $s_data['name'] . ': ' . implode(', ',$section->getErrorMsg());
+                }
+            }
+
+            // Services
+            if (isset($data['services']) && is_array($data['services'])) {
+                if ($import_mode == 'overwrite_all') {
+                    Db::getInstance()->execute('DELETE FROM `'._DB_PREFIX_.'mltheme_services_lang` WHERE id_shop = '.$id_shop);
+                    Db::getInstance()->execute('DELETE FROM `'._DB_PREFIX_.'mltheme_services`');
+                }
+                foreach ($data['services'] as $s_data) {
+                    // Merge logic for services might be by title in default lang if no unique internal name
+                    $service = new MlThemeService(null, null, $id_shop); // Simpler to always create for now
+                    $service->icon = $s_data['icon'];
+                    $service->position = $s_data['position'];
+                    $service->active = $s_data['active'];
+                     foreach ($languages as $lang) {
+                        $id_l = (int)$lang['id_lang'];
+                        $iso = $lang['iso_code'];
+                        $service->title[$id_l] = $s_data['titles'][$iso] ?? $s_data['titles'][$id_l] ?? $s_data['titles'][$default_lang_id] ?? 'Service';
+                        $service->description[$id_l] = $s_data['descriptions'][$iso] ?? $s_data['descriptions'][$id_l] ?? $s_data['descriptions'][$default_lang_id] ?? '';
+                    }
+                    if (!$service->save()) $errors[] = $this->l('Error saving service ') . ($service->title[$default_lang_id] ?? 'Unknown');
+                }
+            }
+
+            // Brands
+            if (isset($data['brands']) && is_array($data['brands'])) {
+                if ($import_mode == 'overwrite_all') {
+                    Db::getInstance()->execute('DELETE FROM `'._DB_PREFIX_.'mltheme_brands`'); // Assuming brands are global or add shop condition
+                }
+                 foreach ($data['brands'] as $b_data) {
+                    // Merge for brands could be by name
+                    $brand = new MlThemeBrand(null, null, $id_shop); // Simpler to always create for now
+                    $brand->name = $b_data['name'];
+                    $brand->logo = $b_data['logo']; // Assumes logo files will be manually handled or exist
+                    $brand->url = $b_data['url'];
+                    $brand->position = $b_data['position'];
+                    $brand->active = $b_data['active'];
+                    if (!$brand->save()) $errors[] = $this->l('Error saving brand ') . $b_data['name'];
+                 }
+            }
+
+            if (!empty($errors)) {
+                Db::getInstance()->rollback();
+                $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Import failed with errors:'), 'errors' => $errors]));
+            }
+
+            Db::getInstance()->commit();
+            $this->moduleInstance->clearCache('*');
+            $this->ajaxDie(json_encode(['success' => true, 'message' => $this->l('Configuration imported successfully.')]));
+
+        } catch (Exception $e) {
+            Db::getInstance()->rollback();
+            $this->ajaxDie(json_encode(['error' => true, 'message' => $this->l('Exception during import: ') . $e->getMessage()]));
+        }
+    }
+}

--- a/modules/mlthemebuilder/controllers/admin/index.php
+++ b/modules/mlthemebuilder/controllers/admin/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/mlthemebuilder/index.php
+++ b/modules/mlthemebuilder/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/mlthemebuilder/mlthemebuilder.php
+++ b/modules/mlthemebuilder/mlthemebuilder.php
@@ -1,0 +1,691 @@
+<?php
+/**
+ * MlThemeBuilder Module for PrestaShop - Mundo Limpio
+ * @author Byron Briones - bbrion.es
+ * @version 1.0.0
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+// Autoload classes from the 'classes' directory
+spl_autoload_register(function ($class_name) {
+    $file = _PS_MODULE_DIR_ . 'mlthemebuilder/classes/' . $class_name . '.php';
+    if (file_exists($file)) {
+        require_once $file;
+    }
+});
+
+
+class MlThemeBuilder extends Module
+{
+    public $tabs = array(
+        array(
+            'name' => 'Theme Builder', // The name displayed in the BO
+            'class_name' => 'AdminMlThemeBuilder', // The name of your AdminController
+            'parent_class_name' => 'IMPROVE', // Parent tab
+            'visible' => true,
+            'icon' => 'icon-paint-brush',
+        ),
+    );
+
+    public function __construct()
+    {
+        $this->name = 'mlthemebuilder';
+        $this->tab = 'front_office_features'; // Default tab for module list
+        $this->version = '1.0.0';
+        $this->author = 'Byron Briones';
+        $this->author_uri = 'https://bbrion.es';
+        $this->need_instance = 0;
+        $this->ps_versions_compliancy = array('min' => '1.7.6', 'max' => _PS_VERSION_); // Adjusted for modern PrestaShop
+        $this->bootstrap = true; // Use Bootstrap for configuration page
+
+        parent::__construct();
+
+        $this->displayName = $this->l('Mundo Limpio Theme Builder');
+        $this->description = $this->l('Módulo para personalizar completamente el tema de tu tienda Mundo Limpio.');
+        $this->confirmUninstall = $this->l('¿Estás seguro de que quieres desinstalar este módulo? Todos los datos de configuración se perderán.');
+
+        // Define module_key, set to a unique value or leave empty if not submitting to Addons
+        $this->module_key = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4'; // Example key
+    }
+
+    public function install()
+    {
+        if (parent::install() &&
+            $this->registerHook('displayHeader') &&
+            $this->registerHook('displayFooter') &&
+            $this->registerHook('displayHome') && // Main hook for homepage sections
+            $this->registerHook('actionAdminControllerSetMedia') && // To add JS/CSS to admin
+            $this->installModuleTabs() &&
+            $this->createTables() &&
+            $this->installDefaultData()) {
+
+            // Set default configuration values
+            Configuration::updateValue('MLTHEME_PRIMARY_COLOR', '#667eea');
+            Configuration::updateValue('MLTHEME_ENABLE_ANIMATIONS', 1);
+
+            return true;
+        }
+        return false;
+    }
+
+    public function uninstall()
+    {
+        if (parent::uninstall() &&
+            $this->uninstallModuleTabs() &&
+            $this->deleteTables()) {
+
+            // Delete configuration values
+            Configuration::deleteByName('MLTHEME_PRIMARY_COLOR');
+            Configuration::deleteByName('MLTHEME_ENABLE_ANIMATIONS');
+            // Delete other config values as needed
+
+            return true;
+        }
+        return false;
+    }
+
+    private function createTables()
+    {
+        $sql = array();
+        $db_prefix = _DB_PREFIX_;
+        $mysql_engine = _MYSQL_ENGINE_;
+
+        // Table for sections
+        $sql[] = "CREATE TABLE IF NOT EXISTS `{$db_prefix}mltheme_sections` (
+            `id_mltheme_section` int(11) NOT NULL AUTO_INCREMENT,
+            `name` varchar(255) NOT NULL COMMENT 'Internal name for identification',
+            `type` varchar(50) NOT NULL COMMENT 'Type of section (hero, products, etc.)',
+            `position` int(11) NOT NULL DEFAULT 0,
+            `active` tinyint(1) NOT NULL DEFAULT 1,
+            `config` text COMMENT 'JSON configuration for the section',
+            `date_add` datetime NOT NULL,
+            `date_upd` datetime NOT NULL,
+            PRIMARY KEY (`id_mltheme_section`)
+        ) ENGINE={$mysql_engine} DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
+
+        // Language table for sections
+        $sql[] = "CREATE TABLE IF NOT EXISTS `{$db_prefix}mltheme_sections_lang` (
+            `id_mltheme_section` int(11) NOT NULL,
+            `id_lang` int(11) NOT NULL,
+            `id_shop` int(11) NOT NULL DEFAULT 1,
+            `title` varchar(255) DEFAULT NULL,
+            `content` text DEFAULT NULL,
+            `button_text` varchar(100) DEFAULT NULL,
+            `button_link` varchar(255) DEFAULT NULL,
+            PRIMARY KEY (`id_mltheme_section`, `id_lang`, `id_shop`)
+        ) ENGINE={$mysql_engine} DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
+
+        // Table for services
+        $sql[] = "CREATE TABLE IF NOT EXISTS `{$db_prefix}mltheme_services` (
+            `id_mltheme_service` int(11) NOT NULL AUTO_INCREMENT,
+            `icon` varchar(255) DEFAULT NULL,
+            `position` int(11) NOT NULL DEFAULT 0,
+            `active` tinyint(1) NOT NULL DEFAULT 1,
+            `date_add` datetime NOT NULL,
+            `date_upd` datetime NOT NULL,
+            PRIMARY KEY (`id_mltheme_service`)
+        ) ENGINE={$mysql_engine} DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
+
+        // Language table for services
+        $sql[] = "CREATE TABLE IF NOT EXISTS `{$db_prefix}mltheme_services_lang` (
+            `id_mltheme_service` int(11) NOT NULL,
+            `id_lang` int(11) NOT NULL,
+            `id_shop` int(11) NOT NULL DEFAULT 1,
+            `title` varchar(255) DEFAULT NULL,
+            `description` text DEFAULT NULL,
+            PRIMARY KEY (`id_mltheme_service`, `id_lang`, `id_shop`)
+        ) ENGINE={$mysql_engine} DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
+
+        // Table for brands
+        $sql[] = "CREATE TABLE IF NOT EXISTS `{$db_prefix}mltheme_brands` (
+            `id_mltheme_brand` int(11) NOT NULL AUTO_INCREMENT,
+            `name` varchar(255) NOT NULL,
+            `logo` varchar(255) DEFAULT NULL COMMENT 'Filename of the logo image',
+            `url` varchar(255) DEFAULT NULL,
+            `position` int(11) NOT NULL DEFAULT 0,
+            `active` tinyint(1) NOT NULL DEFAULT 1,
+            `date_add` datetime NOT NULL,
+            `date_upd` datetime NOT NULL,
+            PRIMARY KEY (`id_mltheme_brand`)
+        ) ENGINE={$mysql_engine} DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
+
+        // Table for global styles and advanced settings (alternative to multiple Configuration entries)
+        $sql[] = "CREATE TABLE IF NOT EXISTS `{$db_prefix}mltheme_settings` (
+            `id_mltheme_setting` int(11) NOT NULL AUTO_INCREMENT,
+            `id_shop_group` int(11) DEFAULT NULL,
+            `id_shop` int(11) DEFAULT NULL,
+            `name` varchar(255) NOT NULL,
+            `value` longtext,
+            `date_add` datetime NOT NULL,
+            `date_upd` datetime NOT NULL,
+            PRIMARY KEY (`id_mltheme_setting`),
+            UNIQUE KEY `idx_mltheme_settings_name_shop_group_shop` (`name`, `id_shop_group`, `id_shop`)
+        ) ENGINE={$mysql_engine} DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
+
+
+        foreach ($sql as $query) {
+            if (!Db::getInstance()->execute($query)) {
+                $this->_errors[] = Db::getInstance()->getMsgError();
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private function deleteTables()
+    {
+        $sql = array(
+            'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'mltheme_sections_lang`',
+            'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'mltheme_sections`',
+            'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'mltheme_services_lang`',
+            'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'mltheme_services`',
+            'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'mltheme_brands`',
+            'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'mltheme_settings`',
+        );
+
+        foreach ($sql as $query) {
+            if (!Db::getInstance()->execute($query)) {
+                // Log error or handle if needed, but uninstall should proceed
+            }
+        }
+        return true;
+    }
+
+    public function installModuleTabs()
+    {
+        $languages = Language::getLanguages(false);
+        foreach ($this->tabs as $tabDetails) {
+            $tab = new Tab();
+            $tab->class_name = $tabDetails['class_name'];
+            $tab->module = $this->name;
+            $tab->id_parent = (int)Tab::getIdFromClassName($tabDetails['parent_class_name']);
+            $tab->active = $tabDetails['visible'] ? 1 : 0;
+            $tab->icon = $tabDetails['icon'] ?? null;
+
+            foreach ($languages as $lang) {
+                // Tab names should be in English and then translated via PrestaShop's translation system
+                // For module tabs, the name often comes from the module itself or a generic term.
+                $tab->name[$lang['id_lang']] = $this->getTranslator()->trans($tabDetails['name'], [], 'Modules.Mlthemebuilder.Admin');
+            }
+            if (!$tab->save()) {
+                $this->_errors[] = $this->l('Failed to install tab: ') . $tabDetails['name'];
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public function uninstallModuleTabs()
+    {
+        foreach ($this->tabs as $tabDetails) {
+            $id_tab = (int)Tab::getIdFromClassName($tabDetails['class_name']);
+            if ($id_tab) {
+                $tab = new Tab($id_tab);
+                if (Validate::isLoadedObject($tab)) {
+                    if (!$tab->delete()) {
+                        $this->_errors[] = $this->l('Failed to uninstall tab: ') . $tabDetails['name'];
+                        // Continue trying to uninstall other tabs
+                    }
+                }
+            }
+        }
+        return empty($this->_errors); // Return true if no errors
+    }
+
+    private function installDefaultData()
+    {
+        $default_sections = array(
+            array('name' => 'hero_main', 'type' => 'hero', 'position' => 1, 'active' => 1, 'config' => '{}',
+                  'title' => array('es' => 'Bienvenido a Mundo Limpio', 'en' => 'Welcome to Mundo Limpio'),
+                  'content' => array('es' => 'Soluciones ecológicas para un futuro sostenible.', 'en' => 'Ecological solutions for a sustainable future.'),
+                  'button_text' => array('es' => 'Ver Productos', 'en' => 'View Products'), 'button_link' => array('es' => '#', 'en' => '#')),
+            array('name' => 'services_overview', 'type' => 'services', 'position' => 2, 'active' => 1, 'config' => '{"columns_services": 3}',
+                  'title' => array('es' => 'Nuestros Servicios', 'en' => 'Our Services')),
+            array('name' => 'featured_products', 'type' => 'products', 'position' => 3, 'active' => 1, 'config' => '{"display_type_products": "featured", "num_products": 4}',
+                  'title' => array('es' => 'Productos Destacados', 'en' => 'Featured Products')),
+            array('name' => 'cta_banner_promo', 'type' => 'banner', 'position' => 4, 'active' => 1, 'config' => '{}',
+                  'title' => array('es' => 'Oferta Especial', 'en' => 'Special Offer')),
+            array('name' => 'trusted_brands', 'type' => 'brands', 'position' => 5, 'active' => 1, 'config' => '{}',
+                  'title' => array('es' => 'Marcas de Confianza', 'en' => 'Trusted Brands')),
+            array('name' => 'ecology_commitment', 'type' => 'ecology', 'position' => 6, 'active' => 1, 'config' => '{}',
+                  'title' => array('es' => 'Compromiso Ecológico', 'en' => 'Ecological Commitment')),
+            array('name' => 'contact_us', 'type' => 'contact', 'position' => 7, 'active' => 1, 'config' => '{"show_form_contact": true}',
+                  'title' => array('es' => 'Contáctanos', 'en' => 'Contact Us')),
+        );
+
+        $languages = Language::getLanguages(false);
+
+        foreach ($default_sections as $section_data) {
+            $section = new MlThemeSection(); // Use the new class name
+            $section->name = $section_data['name'];
+            $section->type = $section_data['type'];
+            $section->position = $section_data['position'];
+            $section->active = $section_data['active'];
+            $section->config = $section_data['config'];
+
+            foreach ($languages as $lang) {
+                $id_lang = (int)$lang['id_lang'];
+                $iso_code = $lang['iso_code'];
+                $section->title[$id_lang] = $section_data['title'][$iso_code] ?? $section_data['title']['en'] ?? $section_data['name'];
+                $section->content[$id_lang] = $section_data['content'][$iso_code] ?? $section_data['content']['en'] ?? '';
+                $section->button_text[$id_lang] = $section_data['button_text'][$iso_code] ?? $section_data['button_text']['en'] ?? '';
+                $section->button_link[$id_lang] = $section_data['button_link'][$iso_code] ?? $section_data['button_link']['en'] ?? '#';
+            }
+
+            if (!$section->add()) {
+                $this->_errors[] = $this->l('Failed to install default section: ') . $section_data['name'];
+            }
+        }
+
+        // Default Services
+        $default_services = [
+            ['icon' => 'fas fa-recycle', 'title' => ['es' => 'Reciclaje Eficiente', 'en' => 'Efficient Recycling'], 'description' => ['es' => 'Optimizamos procesos de reciclaje.', 'en' => 'We optimize recycling processes.']],
+            ['icon' => 'fas fa-leaf', 'title' => ['es' => 'Productos Ecológicos', 'en' => 'Eco-Friendly Products'], 'description' => ['es' => 'Amplia gama de productos sostenibles.', 'en' => 'Wide range of sustainable products.']],
+            ['icon' => 'fas fa-lightbulb', 'title' => ['es' => 'Consultoría Verde', 'en' => 'Green Consulting'], 'description' => ['es' => 'Asesoramiento para un impacto positivo.', 'en' => 'Advice for a positive impact.']],
+        ];
+
+        foreach ($default_services as $idx => $service_data) {
+            $service = new MlThemeService();
+            $service->icon = $service_data['icon'];
+            $service->position = $idx + 1;
+            $service->active = 1;
+            foreach ($languages as $lang) {
+                $id_lang = (int)$lang['id_lang'];
+                $iso_code = $lang['iso_code'];
+                $service->title[$id_lang] = $service_data['title'][$iso_code] ?? $service_data['title']['en'];
+                $service->description[$id_lang] = $service_data['description'][$iso_code] ?? $service_data['description']['en'];
+            }
+            $service->add();
+        }
+
+        return empty($this->_errors);
+    }
+
+    /**
+     * Main configuration page for the module.
+     */
+    public function getContent()
+    {
+        // This method is called when the "Configure" button is clicked in the module list,
+        // or when navigating to the module's admin tab.
+        // It should output the HTML for the configuration page.
+        Tools::redirectAdmin($this->context->link->getAdminLink('AdminMlThemeBuilder'));
+        return null; // Redirecting, so no output needed here.
+    }
+
+    /**
+     * Hook for adding CSS/JS to the admin controller pages.
+     */
+    public function hookActionAdminControllerSetMedia()
+    {
+        // Only add on our module's controller page
+        if (Tools::getValue('controller') == 'AdminMlThemeBuilder' ||
+            (Tools::getValue('configure') == $this->name && Tools::getValue('tab_module') == $this->tab && Tools::getValue('module_name') == $this->name)
+           ) {
+            $this->context->controller->addJqueryUI('ui.sortable');
+            $this->context->controller->addJS($this->_path . 'views/js/admin.js');
+            $this->context->controller->addCSS($this->_path . 'views/css/admin.css');
+
+            // For image uploads with preview
+            $this->context->controller->addJS(_PS_JS_DIR_.'admin/tinymce.inc.js'); // For PS functions like createTemplate
+            $this->context->controller->addJS(_PS_JS_DIR_.'tiny_mce/tiny_mce.js'); // Core TinyMCE if using its image uploader
+
+            // Add translations to JavaScript
+            Media::addJsDef($this->getJsTranslations());
+        }
+    }
+
+    private function getJsTranslations()
+    {
+        return array(
+            'ctb_translations' => array( // Keep same JS var name for existing TPLs, or update TPLs too
+                'orderUpdated' => $this->l('Order updated successfully'),
+                'errorUpdatingOrder' => $this->l('Error updating order'),
+                'configSaved' => $this->l('Configuration saved successfully'),
+                'errorSavingConfig' => $this->l('Error saving configuration'),
+                'statusUpdated' => $this->l('Status updated successfully'),
+                'errorUpdatingStatus' => $this->l('Error updating status'),
+                'confirmDeleteSection' => $this->l('Are you sure you want to delete this section?'),
+                'sectionDeleted' => $this->l('Section deleted successfully.'),
+                'errorDeletingSection' => $this->l('Error deleting section.'),
+                'confirmDeleteService' => $this->l('Are you sure you want to delete this service?'),
+                'serviceDeleted' => $this->l('Service deleted successfully.'),
+                'errorDeletingService' => $this->l('Error deleting service.'),
+                'confirmDeleteBrand' => $this->l('Are you sure you want to delete this brand?'),
+                'brandDeleted' => $this->l('Brand deleted successfully.'),
+                'errorDeletingBrand' => $this->l('Error deleting brand.'),
+                'loading' => $this->l('Loading...'),
+                'errorLoadingForm' => $this->l('Error loading configuration form.'),
+                'imgUploadSuccess' => $this->l('Image uploaded successfully.'),
+                'imgUploadError' => $this->l('Error uploading image.'),
+                'selectAnImage' => $this->l('Please select an image file.'),
+                'itemAdded' => $this->l('Item added.'),
+                'itemRemoved' => $this->l('Item removed.'),
+                'selectPartsToExport' => $this->l('Please select at least one part to export.'),
+                'importingConfig' => $this->l('Importing configuration...'),
+                'errorImportingConfig' => $this->l('Error importing configuration.'),
+                'errorImportingConfigAjax' => $this->l('AJAX error during import.'),
+            )
+        );
+    }
+
+
+    public function hookDisplayHeader($params)
+    {
+        // Add global CSS
+        $this->context->controller->addCSS($this->_path . 'views/css/front.css', 'all');
+
+        // Add global JS
+        $this->context->controller->addJS($this->_path . 'views/js/front.js');
+
+        // Add animations CSS if enabled
+        // Using MlThemeSetting class to get this value
+        $enable_animations = MlThemeSetting::getSettingValue('enable_animations', $this->context->shop->id, true);
+        if ($enable_animations) {
+            $this->context->controller->addCSS($this->_path . 'views/css/animations.css', 'all');
+        }
+
+        // Add Google Fonts if URL is set
+        $google_fonts_url = MlThemeSetting::getSettingValue('google_fonts_url', $this->context->shop->id);
+        if ($google_fonts_url && Validate::isAbsoluteUrl($google_fonts_url)) {
+            $this->context->controller->registerStylesheet(
+                'module-' . $this->name . '-googlefonts',
+                $google_fonts_url,
+                ['server' => 'remote', 'priority' => 10]
+            );
+        }
+
+        // Add custom CSS from settings
+        $custom_css = MlThemeSetting::getSettingValue('custom_css', $this->context->shop->id);
+        if ($custom_css) {
+            $this->context->smarty->assign('mltheme_custom_css', $custom_css);
+        }
+
+        // Add custom JS from settings (header)
+        $custom_js_header = MlThemeSetting::getSettingValue('custom_js_header', $this->context->shop->id);
+         if ($custom_js_header) {
+            $this->context->smarty->assign('mltheme_custom_js_header', $custom_js_header);
+        }
+
+        // Assign global style variables to Smarty for inline styling or CSS variables
+        $global_styles = MlThemeSetting::getMultipleSettings([
+            'primary_color', 'secondary_color', 'text_color', 'link_color',
+            'bg_light_color', 'bg_dark_color', 'base_font_size', 'button_border_radius'
+        ], $this->context->shop->id);
+
+        $this->context->smarty->assign('mltheme_global_styles', $global_styles);
+
+        return $this->display(__FILE__, 'views/templates/hook/header.tpl');
+    }
+
+    public function hookDisplayFooter($params)
+    {
+        // Add custom JS from settings (footer)
+        $custom_js_footer = MlThemeSetting::getSettingValue('custom_js_footer', $this->context->shop->id);
+        if ($custom_js_footer) {
+            $this->context->smarty->assign('mltheme_custom_js_footer', $custom_js_footer);
+        }
+        return $this->display(__FILE__, 'views/templates/hook/footer.tpl');
+    }
+
+    public function hookDisplayHome($params)
+    {
+        $output = '';
+        $id_lang = (int)$this->context->language->id;
+        $id_shop = (int)$this->context->shop->id;
+
+        $sections = MlThemeSection::getSectionsByPosition(true, $id_lang, $id_shop);
+
+        if ($sections) {
+            foreach ($sections as $section_data) {
+                // Create an instance of the section to easily access its properties
+                $section_obj = new MlThemeSection((int)$section_data['id_mltheme_section'], $id_lang, $id_shop);
+                if (Validate::isLoadedObject($section_obj) && $section_obj->active) {
+                     $output .= $this->renderSection($section_obj);
+                }
+            }
+        }
+        return $output;
+    }
+
+    private function renderSection(MlThemeSection $section) // Use new class name
+    {
+        $template_file_path = 'views/templates/hook/sections/' . $section->type . '.tpl';
+        $template_full_path = $this->getLocalPath() . $template_file_path;
+
+        if (!file_exists($template_full_path)) {
+            // Optionally log this error or return a placeholder
+            // error_log("Template not found for section type: {$section->type}");
+            return '<div class="alert alert-warning">Section template `'.$section->type.'.tpl` not found.</div>';
+        }
+
+        $cache_id = $this->name . '|' . $section->type . '|' . $section->id . '|' . $this->context->language->id . '|' . $this->context->shop->id;
+
+        // Check if section caching is enabled
+        $enable_section_cache = MlThemeSetting::getSettingValue('enable_section_cache', $this->context->shop->id, true);
+
+        if (!$enable_section_cache || !$this->isCached($template_file_path, $cache_id)) {
+            $section_render_data = array();
+            $section_render_data['section'] = (array)$section; // Basic section data
+
+            // Multilingual fields are already loaded in $section object if $id_lang was passed to constructor
+            $section_render_data['section']['title'] = $section->title;
+            $section_render_data['section']['content'] = $section->content;
+            $section_render_data['section']['button_text'] = $section->button_text;
+            $section_render_data['section']['button_link'] = $section->button_link;
+
+            $section_render_data['section']['config'] = json_decode($section->config, true);
+            if ($section_render_data['section']['config'] === null) $section_render_data['section']['config'] = [];
+
+            // Add id_section for convenience in template
+            $section_render_data['section']['id_section'] = $section->id;
+
+
+            // Load specific data based on section type by calling dedicated methods
+            $methodName = 'get' . ucfirst($section->type) . 'Data';
+            if (method_exists($this, $methodName)) {
+                $specific_data = $this->$methodName($section);
+                $section_render_data['section'] = array_merge($section_render_data['section'], $specific_data);
+            }
+
+            // Common variables for all section templates
+            $section_render_data['img_dir_theme'] = $this->context->link->getMediaLink($this->_path . 'views/img/');
+            $section_render_data['language'] = $this->context->language;
+
+
+            $this->context->smarty->assign($section_render_data);
+        }
+        return $this->fetch($template_file_path, ($enable_section_cache ? $cache_id : null));
+    }
+
+    // Data retrieval methods for each section type
+    private function getHeroData(MlThemeSection $section)
+    {
+        $config = $section->config ? json_decode($section->config, true) : []; // Already decoded in renderSection
+        $id_lang = $this->context->language->id;
+
+        // Fallbacks: Config -> Object Property -> Default Translatable String
+        $data = [];
+        $data['hero_title'] = $config['title_hero'][$id_lang] ?? $section->title ?? $this->l('Main Title Hero', 'mlthemebuilder');
+        $data['hero_subtitle'] = $config['subtitle_hero'][$id_lang] ?? '';
+        $data['hero_image'] = $config['image_hero'] ?? ''; // Filename, path constructed in TPL
+        $data['hero_button_text'] = $config['button_text_hero'][$id_lang] ?? $section->button_text ?? $this->l('View Products', 'mlthemebuilder');
+        $data['hero_button_link'] = $config['button_link_hero'][$id_lang] ?? $section->button_link ?? Context::getContext()->link->getPageLink('index');
+
+        return $data;
+    }
+
+    private function getServicesData(MlThemeSection $section)
+    {
+        $config = $section->config ? json_decode($section->config, true) : [];
+        $id_lang = $this->context->language->id;
+        $id_shop = $this->context->shop->id;
+
+        $limit = $config['max_services'] ?? null;
+
+        return array(
+            'services_list_title' => $config['title_services'][$id_lang] ?? $section->title ?? $this->l('Our Services', 'mlthemebuilder'),
+            'services_list_subtitle' => $config['subtitle_services'][$id_lang] ?? $section->content ?? '',
+            'services_list' => MlThemeService::getActiveServices($id_lang, $id_shop, $limit),
+            'columns_services' => $config['columns_services'] ?? 3,
+        );
+    }
+
+    private function getProductsData(MlThemeSection $section)
+    {
+        $config = $section->config ? json_decode($section->config, true) : [];
+        $id_lang = $this->context->language->id;
+
+        $data = [];
+        $data['products_list_title'] = $config['title_products'][$id_lang] ?? $section->title ?? $this->l('Featured Products', 'mlthemebuilder');
+        $data['products_list_subtitle'] = $config['subtitle_products'][$id_lang] ?? $section->content ?? '';
+
+        $display_type = $config['display_type_products'] ?? 'featured'; // featured, new, category, bestsellers
+        $num_products = isset($config['num_products']) ? (int)$config['num_products'] : 8;
+        $id_category = isset($config['id_category_products']) ? (int)$config['id_category_products'] : null;
+
+        $products = [];
+        if ($display_type == 'category' && $id_category) {
+            $category = new Category($id_category, $id_lang);
+            if (Validate::isLoadedObject($category)) {
+                $products = $category->getProducts($id_lang, 1, $num_products, 'position'); // Or by date_add, etc.
+            }
+        } elseif ($display_type == 'new') {
+            $products = Product::getNewProducts($id_lang, 0, $num_products);
+        } elseif ($display_type == 'bestsellers') {
+            $products = ProductSale::getBestSales($id_lang, 0, $num_products);
+        } else { // Default to featured (on sale)
+            $products = Product::getPricesDrop($id_lang, 0, $num_products, false); // PrestaShop's "on sale"
+             if (!$products) { // Fallback if no products on sale
+                $products = Product::getNewProducts($id_lang, 0, $num_products);
+            }
+        }
+
+        $presenterFactory = new ProductPresenterFactory($this->context);
+        $presentationSettings = $presenterFactory->getPresentationSettings();
+        $productPresenter = $presenterFactory->getPresenter();
+
+        $data['products_list'] = [];
+        if ($products) {
+            foreach ($products as $product) {
+                $data['products_list'][] = $productPresenter->present(
+                    $presentationSettings,
+                    $product,
+                    $this->context->language
+                );
+            }
+        }
+
+        // For category display type
+        if ($display_type == 'categories') {
+             $data['categories_list'] = Category::getCategories($id_lang, true, false); // Simple list of categories
+             // More complex category data might be needed depending on TPL
+        }
+
+        return $data;
+    }
+
+    private function getBrandsData(MlThemeSection $section)
+    {
+        $config = $section->config ? json_decode($section->config, true) : [];
+        $id_lang = $this->context->language->id; // Not directly used for brands unless they become translatable
+
+        $limit = $config['max_brands'] ?? null;
+
+        return array(
+            'brands_list_title' => $config['title_brands'][$id_lang] ?? $section->title ?? $this->l('Our Brands', 'mlthemebuilder'),
+            'brands_list' => MlThemeBrand::getActiveBrands($this->context->shop->id, $limit)
+        );
+    }
+
+    private function getBannerData(MlThemeSection $section)
+    {
+        $config = $section->config ? json_decode($section->config, true) : [];
+        $id_lang = $this->context->language->id;
+
+        $data = [];
+        $data['banner_title'] = $config['title_banner'][$id_lang] ?? $section->title ?? '';
+        $data['banner_text'] = $config['text_banner'][$id_lang] ?? $section->content ?? '';
+        $data['banner_image'] = $config['image_banner'] ?? ''; // Filename
+        $data['banner_background_image'] = $config['background_image_banner'] ?? ''; // Filename
+        $data['banner_background_color'] = $config['background_color_banner'] ?? '';
+        $data['banner_button_text'] = $config['button_text_banner'][$id_lang] ?? $section->button_text ?? '';
+        $data['banner_button_link'] = $config['button_link_banner'][$id_lang] ?? $section->button_link ?? '';
+        $data['layout_banner'] = $config['layout_banner'] ?? 'image_right'; // image_left, image_right, text_only, image_background
+
+        return $data;
+    }
+
+    private function getEcologyData(MlThemeSection $section)
+    {
+        $config = $section->config ? json_decode($section->config, true) : [];
+        $id_lang = $this->context->language->id;
+
+        $data = [];
+        $data['ecology_title'] = $config['title_ecology'][$id_lang] ?? $section->title ?? $this->l('Ecological Commitment', 'mlthemebuilder');
+        $data['ecology_text'] = $config['text_ecology'][$id_lang] ?? $section->content ?? '';
+        $data['ecology_image'] = $config['image_ecology'] ?? ''; // Filename
+        $data['layout_ecology'] = $config['layout_ecology'] ?? 'image_right';
+
+        $items = [];
+        if (isset($config['items_ecology']) && is_array($config['items_ecology'])) {
+            foreach ($config['items_ecology'] as $item_conf) {
+                $items[] = [
+                    'text' => $item_conf['text'][$id_lang] ?? '',
+                    'icon' => $item_conf['icon'] ?? ''
+                ];
+            }
+        }
+        $data['ecology_items_list'] = $items;
+        return $data;
+    }
+
+    private function getContactData(MlThemeSection $section)
+    {
+        $config = $section->config ? json_decode($section->config, true) : [];
+        $id_lang = $this->context->language->id;
+
+        $data = [];
+        $data['contact_title'] = $config['title_contact'][$id_lang] ?? $section->title ?? $this->l('Contact Us', 'mlthemebuilder');
+        $data['contact_address'] = $config['address_contact'][$id_lang] ?? Configuration::get('PS_SHOP_ADDR1');
+        $data['contact_phone'] = $config['phone_contact'][$id_lang] ?? Configuration::get('PS_SHOP_PHONE');
+        $data['contact_email'] = $config['email_contact'][$id_lang] ?? Configuration::get('PS_SHOP_EMAIL');
+        $data['contact_hours'] = $config['hours_contact'][$id_lang] ?? '';
+        $data['show_form_contact'] = $config['show_form_contact'] ?? true;
+        $data['show_map_contact'] = $config['show_map_contact'] ?? false;
+        $data['map_embed_code_contact'] = $config['map_embed_code_contact'] ?? ''; // Should be sanitized if outputting directly
+
+        return $data;
+    }
+
+    /**
+     * Gets the path to the module's image directory.
+     * @param string $type 'icons', 'sections', 'brands', etc.
+     * @return string Physical path.
+     */
+    public functiongetLocalImgPath($type = null)
+    {
+        $path = $this->getLocalPath().'views/img/';
+        if ($type && is_string($type) && preg_match('/^[a-zA-Z0-9_-]+$/', $type)) {
+            $path .= $type . '/';
+        }
+        return $path;
+    }
+
+    /**
+     * Gets the URL to the module's image directory.
+     * @param string $type 'icons', 'sections', 'brands', etc.
+     * @return string URL.
+     */
+    public functiongetModuleImgUri($type = null)
+    {
+        $uri = $this->_path.'views/img/';
+        if ($type && is_string($type) && preg_match('/^[a-zA-Z0-9_-]+$/', $type)) {
+            $uri .= $type . '/';
+        }
+        return $uri;
+    }
+}

--- a/modules/mlthemebuilder/sql/index.php
+++ b/modules/mlthemebuilder/sql/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/mlthemebuilder/sql/install.sql
+++ b/modules/mlthemebuilder/sql/install.sql
@@ -1,0 +1,90 @@
+-- SQL Schema for MlThemeBuilder Module
+
+-- Table for theme sections
+CREATE TABLE IF NOT EXISTS `PREFIX_mltheme_sections` (
+    `id_mltheme_section` int(11) NOT NULL AUTO_INCREMENT,
+    `name` varchar(255) NOT NULL COMMENT 'Internal name for identification',
+    `type` varchar(50) NOT NULL COMMENT 'Type of section (hero, products, etc.)',
+    `position` int(11) NOT NULL DEFAULT 0,
+    `active` tinyint(1) NOT NULL DEFAULT 1,
+    `config` text COMMENT 'JSON configuration for the section',
+    `date_add` datetime NOT NULL,
+    `date_upd` datetime NOT NULL,
+    -- `id_shop` int(11) unsigned NOT NULL DEFAULT 1, -- Uncomment if sections are shop-specific in main table
+    PRIMARY KEY (`id_mltheme_section`)
+    -- KEY `idx_id_shop` (`id_shop`) -- Uncomment if sections are shop-specific
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Language table for theme sections
+CREATE TABLE IF NOT EXISTS `PREFIX_mltheme_sections_lang` (
+    `id_mltheme_section` int(11) NOT NULL,
+    `id_lang` int(11) NOT NULL,
+    `id_shop` int(11) unsigned NOT NULL DEFAULT 1,
+    `title` varchar(255) DEFAULT NULL,
+    `content` text DEFAULT NULL,
+    `button_text` varchar(100) DEFAULT NULL,
+    `button_link` varchar(255) DEFAULT NULL,
+    PRIMARY KEY (`id_mltheme_section`, `id_lang`, `id_shop`)
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Table for services
+CREATE TABLE IF NOT EXISTS `PREFIX_mltheme_services` (
+    `id_mltheme_service` int(11) NOT NULL AUTO_INCREMENT,
+    `icon` varchar(255) DEFAULT NULL,
+    `position` int(11) NOT NULL DEFAULT 0,
+    `active` tinyint(1) NOT NULL DEFAULT 1,
+    `date_add` datetime NOT NULL,
+    `date_upd` datetime NOT NULL,
+    -- `id_shop` int(11) unsigned NOT NULL DEFAULT 1, -- Uncomment if services are shop-specific
+    PRIMARY KEY (`id_mltheme_service`)
+    -- KEY `idx_id_shop` (`id_shop`) -- Uncomment if services are shop-specific
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Language table for services
+CREATE TABLE IF NOT EXISTS `PREFIX_mltheme_services_lang` (
+    `id_mltheme_service` int(11) NOT NULL,
+    `id_lang` int(11) NOT NULL,
+    `id_shop` int(11) unsigned NOT NULL DEFAULT 1,
+    `title` varchar(255) DEFAULT NULL,
+    `description` text DEFAULT NULL,
+    PRIMARY KEY (`id_mltheme_service`, `id_lang`, `id_shop`)
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Table for brands
+CREATE TABLE IF NOT EXISTS `PREFIX_mltheme_brands` (
+    `id_mltheme_brand` int(11) NOT NULL AUTO_INCREMENT,
+    `name` varchar(255) NOT NULL,
+    `logo` varchar(255) DEFAULT NULL COMMENT 'Filename of the logo image',
+    `url` varchar(255) DEFAULT NULL,
+    `position` int(11) NOT NULL DEFAULT 0,
+    `active` tinyint(1) NOT NULL DEFAULT 1,
+    `date_add` datetime NOT NULL,
+    `date_upd` datetime NOT NULL,
+    -- `id_shop` int(11) unsigned NOT NULL DEFAULT 1, -- Uncomment if brands are shop-specific
+    PRIMARY KEY (`id_mltheme_brand`)
+    -- KEY `idx_id_shop` (`id_shop`) -- Uncomment if brands are shop-specific
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Table for global module settings (alternative to PrestaShop Configuration table for complex/multiple settings)
+CREATE TABLE IF NOT EXISTS `PREFIX_mltheme_settings` (
+    `id_mltheme_setting` int(11) NOT NULL AUTO_INCREMENT,
+    `id_shop_group` int(11) unsigned DEFAULT NULL, -- Use NULL for all groups
+    `id_shop` int(11) unsigned DEFAULT NULL, -- Use NULL for all shops (within group or global)
+    `name` varchar(255) NOT NULL COMMENT 'Setting key name',
+    `value` longtext DEFAULT NULL COMMENT 'Setting value (can be JSON for complex data)',
+    `date_add` datetime NOT NULL,
+    `date_upd` datetime NOT NULL,
+    PRIMARY KEY (`id_mltheme_setting`),
+    UNIQUE KEY `idx_mltheme_setting_name_shop_group_shop` (`name`, `id_shop_group`, `id_shop`) -- Ensure unique setting per scope
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Default data insertion will be handled by the module's installDefaultData() method in PHP
+-- This ensures multilingual data and ObjectModel relations are handled correctly.
+-- Example:
+-- INSERT INTO `PREFIX_mltheme_sections` (`name`, `type`, `position`, `active`, `config`, `date_add`, `date_upd`) VALUES
+-- ('hero_main', 'hero', 1, 1, '{}', NOW(), NOW()),
+-- ('services_overview', 'services', 2, 1, '{\"columns_services\":3}', NOW(), NOW());
+-- ... and corresponding _lang table entries.
+
+-- Note: ENGINE_TYPE will be replaced by PrestaShop with _MYSQL_ENGINE_
+-- Note: PREFIX_ will be replaced by PrestaShop with the actual database prefix.

--- a/modules/mlthemebuilder/sql/uninstall.sql
+++ b/modules/mlthemebuilder/sql/uninstall.sql
@@ -1,0 +1,26 @@
+-- SQL Uninstall Script for MlThemeBuilder Module
+
+-- Drop language table for theme sections
+DROP TABLE IF EXISTS `PREFIX_mltheme_sections_lang`;
+
+-- Drop main table for theme sections
+DROP TABLE IF EXISTS `PREFIX_mltheme_sections`;
+
+-- Drop language table for services
+DROP TABLE IF EXISTS `PREFIX_mltheme_services_lang`;
+
+-- Drop main table for services
+DROP TABLE IF EXISTS `PREFIX_mltheme_services`;
+
+-- Drop table for brands
+DROP TABLE IF EXISTS `PREFIX_mltheme_brands`;
+
+-- Drop table for global module settings
+DROP TABLE IF EXISTS `PREFIX_mltheme_settings`;
+
+-- Note: Configuration values stored in PrestaShop's `ps_configuration` table
+-- are typically removed within the module's uninstall() method in PHP using Configuration::deleteByName().
+-- Example:
+-- DELETE FROM `PREFIX_configuration` WHERE `name` LIKE 'MLTHEME_%';
+
+-- It's generally safer to let the PHP uninstall method handle Configuration table cleanup.

--- a/modules/mlthemebuilder/translations/en.php
+++ b/modules/mlthemebuilder/translations/en.php
@@ -1,0 +1,134 @@
+<?php
+
+global $_MODULE;
+$_MODULE = array();
+
+// Default strings from module main class
+$_MODULE['<{mlthemebuilder}prestashop>mlthemebuilder_displayname'] = 'Mundo Limpio Theme Builder';
+$_MODULE['<{mlthemebuilder}prestashop>mlthemebuilder_description'] = 'Module to fully customize the theme of your Mundo Limpio store.';
+$_MODULE['<{mlthemebuilder}prestashop>mlthemebuilder_uninstall_confirm'] = 'Are you sure you want to uninstall this module? All configuration data will be lost.';
+
+// Admin Controller & Tabs
+$_MODULE['<{mlthemebuilder}prestashop>admintab_theme_builder'] = 'Theme Builder';
+$_MODULE['<{mlthemebuilder}prestashop>admintab_configure_title'] = 'Mundo Limpio Theme Builder Configuration';
+
+// General Admin UI
+$_MODULE['<{mlthemebuilder}prestashop>admin_save_success'] = 'Settings saved successfully.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_save_error'] = 'Error saving settings.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_delete_confirm'] = 'Are you sure you want to delete this item?';
+$_MODULE['<{mlthemebuilder}prestashop>admin_item_deleted'] = 'Item deleted successfully.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_item_error_delete'] = 'Error deleting item.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_order_updated'] = 'Order updated successfully.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_order_error'] = 'Error updating order.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_status_updated'] = 'Status updated successfully.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_status_error'] = 'Error updating status.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_loading'] = 'Loading...';
+$_MODULE['<{mlthemebuilder}prestashop>admin_error_form_load'] = 'Error loading configuration form.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_img_upload_success'] = 'Image uploaded successfully.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_img_upload_error'] = 'Error uploading image.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_select_image'] = 'Please select an image file.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_item_added'] = 'Item added successfully.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_item_removed'] = 'Item removed successfully.';
+
+// configure.tpl Tabs
+$_MODULE['<{mlthemebuilder}prestashop>admin_tab_sections'] = 'Sections Management';
+$_MODULE['<{mlthemebuilder}prestashop>admin_tab_styles'] = 'Global Styles';
+$_MODULE['<{mlthemebuilder}prestashop>admin_tab_services_manage'] = 'Manage Services';
+$_MODULE['<{mlthemebuilder}prestashop>admin_tab_brands_manage'] = 'Manage Brands';
+$_MODULE['<{mlthemebuilder}prestashop>admin_tab_advanced'] = 'Advanced Settings';
+$_MODULE['<{mlthemebuilder}prestashop>admin_tab_importexport'] = 'Import/Export';
+
+// sections_manager.tpl
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_title'] = 'Homepage Sections Management';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_infobox'] = 'Drag and drop sections to change their order on the homepage. Click "Configure" to edit a section\'s content and settings. Use the switch to activate or deactivate a section.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_active_sections'] = 'Active Sections';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_drag_reorder'] = 'Drag to reorder';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_enable'] = 'Enable';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_disable'] = 'Disable';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_configure'] = 'Configure';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_delete'] = 'Delete Section';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_internal_name'] = 'Internal Name:';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_position'] = 'Position:';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_no_sections'] = 'No sections created yet. Add a new section to get started.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_add_new'] = 'Add New Section';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_internal_name_label'] = 'Section Internal Name';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_internal_name_placeholder'] = 'e.g., main_slider, featured_products_home';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_internal_name_help'] = 'Used for identification in the backend. Not visible to customers.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_type_label'] = 'Section Type';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_default_title_label'] = 'Default Title';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_default_title_help'] = 'Optional. This title will be visible to customers if set.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_add_button'] = 'Add Section';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_modal_title'] = 'Configure Section';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_modal_close'] = 'Close';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_modal_save'] = 'Save Configuration';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_confirm_delete'] = 'Are you sure you want to delete this section?';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_deleted_msg'] = 'Section deleted successfully.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_error_delete_msg'] = 'Error deleting section.';
+
+// Section Types
+$_MODULE['<{mlthemebuilder}prestashop>section_type_hero'] = 'Hero Banner';
+$_MODULE['<{mlthemebuilder}prestashop>section_type_services'] = 'Services List';
+$_MODULE['<{mlthemebuilder}prestashop>section_type_products'] = 'Products (Category or Featured)';
+$_MODULE['<{mlthemebuilder}prestashop>section_type_banner'] = 'CTA Banner';
+$_MODULE['<{mlthemebuilder}prestashop>section_type_brands'] = 'Brands Slider';
+$_MODULE['<{mlthemebuilder}prestashop>section_type_ecology'] = 'Ecology/Values Section';
+$_MODULE['<{mlthemebuilder}prestashop>section_type_contact'] = 'Contact Information';
+$_MODULE['<{mlthemebuilder}prestashop>section_type_custom_html'] = 'Custom HTML';
+
+// global_styles.tpl
+$_MODULE['<{mlthemebuilder}prestashop>admin_styles_palette_legend'] = 'Color Palette';
+$_MODULE['<{mlthemebuilder}prestashop>admin_styles_primary_color_label'] = 'Primary Color';
+$_MODULE['<{mlthemebuilder}prestashop>admin_styles_primary_color_help'] = 'Main color used for buttons, links, and important elements.';
+// ... Add EN translations for all other labels and help texts from global_styles.tpl
+
+// services_manager.tpl
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_title_page'] = 'Manage Services';
+// ... Add EN translations for services_manager.tpl
+
+// brands_manager.tpl
+$_MODULE['<{mlthemebuilder}prestashop>admin_brands_title_page'] = 'Manage Brands/Partner Logos';
+// ... Add EN translations for brands_manager.tpl
+
+// advanced_settings.tpl
+$_MODULE['<{mlthemebuilder}prestashop>admin_advanced_custom_codes_legend'] = 'Custom Codes';
+// ... Add EN translations for advanced_settings.tpl
+
+// import_export.tpl
+$_MODULE['<{mlthemebuilder}prestashop>admin_importexport_export_legend'] = 'Export Configuration';
+// ... Add EN translations for import_export.tpl
+
+// Section Configuration Forms (hero.tpl, services.tpl, etc. in admin/sections/)
+$_MODULE['<{mlthemebuilder}prestashop>admin_section_hero_title_label'] = 'Main Title';
+// ... Add EN translations for all section config forms
+
+// Frontend section titles (defaults)
+$_MODULE['<{mlthemebuilder}prestashop>shop_hero_default_title'] = 'Welcome to Our Store';
+$_MODULE['<{mlthemebuilder}prestashop>shop_services_default_title'] = 'Our Services';
+$_MODULE['<{mlthemebuilder}prestashop>shop_products_default_title'] = 'Featured Products';
+$_MODULE['<{mlthemebuilder}prestashop>shop_banner_default_title'] = 'Special Offer';
+$_MODULE['<{mlthemebuilder}prestashop>shop_brands_default_title'] = 'Trusted Brands';
+$_MODULE['<{mlthemebuilder}prestashop>shop_ecology_default_title'] = 'Our Ecological Commitment';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contact_default_title'] = 'Contact Us';
+
+// Contact Form Frontend
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_name_placeholder'] = 'Your Name';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_email_placeholder'] = 'Your Email';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_message_placeholder'] = 'Your Message';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_send_button'] = 'Send Message';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_sending'] = 'Sending...';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_success'] = 'Message sent successfully!';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_error'] = 'Error sending message. Please try again.';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_fill_required'] = 'Please fill all required fields.';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_address_label'] = 'Address';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_phone_label'] = 'Phone';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_email_label'] = 'Email';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_hours_label'] = 'Opening Hours';
+
+// General shop texts
+$_MODULE['<{mlthemebuilder}prestashop>shop_view_products_button'] = 'View Products';
+$_MODULE['<{mlthemebuilder}prestashop>shop_view_category_button'] = 'View Category';
+$_MODULE['<{mlthemebuilder}prestashop>shop_no_products_found'] = 'No products found for this selection.';
+$_MODULE['<{mlthemebuilder}prestashop>shop_no_services_available'] = 'No services available at the moment.';
+$_MODULE['<{mlthemebuilder}prestashop>shop_no_brands_available'] = 'No brands to display at the moment.';
+
+return $_MODULE;

--- a/modules/mlthemebuilder/translations/es.php
+++ b/modules/mlthemebuilder/translations/es.php
@@ -1,0 +1,171 @@
+<?php
+
+global $_MODULE;
+$_MODULE = array();
+
+// Default strings from module main class
+$_MODULE['<{mlthemebuilder}prestashop>mlthemebuilder_displayname'] = 'Mundo Limpio Theme Builder';
+$_MODULE['<{mlthemebuilder}prestashop>mlthemebuilder_description'] = 'Módulo para personalizar completamente el tema de tu tienda Mundo Limpio.';
+$_MODULE['<{mlthemebuilder}prestashop>mlthemebuilder_uninstall_confirm'] = '¿Estás seguro de que quieres desinstalar este módulo? Todos los datos de configuración se perderán.';
+
+// Admin Controller & Tabs
+$_MODULE['<{mlthemebuilder}prestashop>admintab_theme_builder'] = 'Theme Builder'; // For the main tab name
+$_MODULE['<{mlthemebuilder}prestashop>admintab_configure_title'] = 'Configuración de Mundo Limpio Theme Builder';
+
+// General Admin UI
+$_MODULE['<{mlthemebuilder}prestashop>admin_save_success'] = 'Configuración guardada correctamente.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_save_error'] = 'Error al guardar la configuración.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_delete_confirm'] = '¿Estás seguro de que quieres eliminar este elemento?';
+$_MODULE['<{mlthemebuilder}prestashop>admin_item_deleted'] = 'Elemento eliminado correctamente.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_item_error_delete'] = 'Error al eliminar el elemento.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_order_updated'] = 'Orden actualizado correctamente.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_order_error'] = 'Error al actualizar el orden.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_status_updated'] = 'Estado actualizado correctamente.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_status_error'] = 'Error al actualizar el estado.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_loading'] = 'Cargando...';
+$_MODULE['<{mlthemebuilder}prestashop>admin_error_form_load'] = 'Error al cargar el formulario de configuración.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_img_upload_success'] = 'Imagen subida correctamente.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_img_upload_error'] = 'Error al subir la imagen.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_select_image'] = 'Por favor, selecciona un archivo de imagen.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_item_added'] = 'Elemento añadido correctamente.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_item_removed'] = 'Elemento eliminado correctamente.';
+
+
+// configure.tpl Tabs
+$_MODULE['<{mlthemebuilder}prestashop>admin_tab_sections'] = 'Gestión de Secciones';
+$_MODULE['<{mlthemebuilder}prestashop>admin_tab_styles'] = 'Estilos Globales';
+$_MODULE['<{mlthemebuilder}prestashop>admin_tab_services_manage'] = 'Gestionar Servicios';
+$_MODULE['<{mlthemebuilder}prestashop>admin_tab_brands_manage'] = 'Gestionar Marcas';
+$_MODULE['<{mlthemebuilder}prestashop>admin_tab_advanced'] = 'Ajustes Avanzados';
+$_MODULE['<{mlthemebuilder}prestashop>admin_tab_importexport'] = 'Importar/Exportar';
+
+// sections_manager.tpl
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_title'] = 'Gestión de Secciones de la Página de Inicio';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_infobox'] = 'Arrastra y suelta las secciones para cambiar su orden en la página de inicio. Haz clic en "Configurar" para editar el contenido y los ajustes de una sección. Usa el interruptor para activar o desactivar una sección.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_active_sections'] = 'Secciones Activas';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_drag_reorder'] = 'Arrastrar para reordenar';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_enable'] = 'Activar';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_disable'] = 'Desactivar';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_configure'] = 'Configurar';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_delete'] = 'Eliminar Sección';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_internal_name'] = 'Nombre Interno:';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_position'] = 'Posición:';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_no_sections'] = 'Aún no se han creado secciones. Añade una nueva sección para empezar.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_add_new'] = 'Añadir Nueva Sección';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_internal_name_label'] = 'Nombre Interno de la Sección';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_internal_name_placeholder'] = 'ej., slider_principal, productos_destacados_inicio';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_internal_name_help'] = 'Usado para identificación en el backend. No visible para los clientes.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_type_label'] = 'Tipo de Sección';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_default_title_label'] = 'Título por Defecto';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_default_title_help'] = 'Opcional. Este título será visible para los clientes si se establece.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_add_button'] = 'Añadir Sección';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_modal_title'] = 'Configurar Sección';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_modal_close'] = 'Cerrar';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_modal_save'] = 'Guardar Configuración';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_confirm_delete'] = '¿Estás seguro de que quieres eliminar esta sección?';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_deleted_msg'] = 'Sección eliminada correctamente.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_sections_error_delete_msg'] = 'Error al eliminar la sección.';
+
+// Section Types (for dropdown and display)
+$_MODULE['<{mlthemebuilder}prestashop>section_type_hero'] = 'Banner Hero';
+$_MODULE['<{mlthemebuilder}prestashop>section_type_services'] = 'Lista de Servicios';
+$_MODULE['<{mlthemebuilder}prestashop>section_type_products'] = 'Productos (Categoría o Destacados)';
+$_MODULE['<{mlthemebuilder}prestashop>section_type_banner'] = 'Banner CTA';
+$_MODULE['<{mlthemebuilder}prestashop>section_type_brands'] = 'Slider de Marcas';
+$_MODULE['<{mlthemebuilder}prestashop>section_type_ecology'] = 'Sección Ecología/Valores';
+$_MODULE['<{mlthemebuilder}prestashop>section_type_contact'] = 'Información de Contacto';
+$_MODULE['<{mlthemebuilder}prestashop>section_type_custom_html'] = 'HTML Personalizado';
+
+
+// global_styles.tpl
+$_MODULE['<{mlthemebuilder}prestashop>admin_styles_palette_legend'] = 'Paleta de Colores';
+$_MODULE['<{mlthemebuilder}prestashop>admin_styles_primary_color_label'] = 'Color Primario';
+$_MODULE['<{mlthemebuilder}prestashop>admin_styles_primary_color_help'] = 'Color principal usado para botones, enlaces y elementos importantes.';
+// ... (add all other labels and help texts from global_styles.tpl)
+
+// services_manager.tpl
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_title_page'] = 'Gestionar Servicios';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_infobox'] = 'Aquí puedes añadir, editar, reordenar y eliminar servicios que se pueden mostrar en la sección "Servicios" en tu página de inicio u otras páginas.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_current_services'] = 'Servicios Actuales';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_no_services'] = 'Aún no se han añadido servicios.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_add_new_title'] = 'Añadir Nuevo Servicio';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_edit_title_prefix'] = 'Editar Servicio: ';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_title_label'] = 'Título';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_description_label'] = 'Descripción';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_icon_label'] = 'Icono';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_icon_placeholder'] = 'ej., fa-star o nombre_icono.png';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_icon_help'] = 'Introduce una clase de FontAwesome (ej., "fas fa-star") o el nombre de archivo de un icono subido a modules/mlthemebuilder/views/img/icons/';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_icon_manage'] = 'Gestionar Iconos Subidos';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_active_label'] = 'Activo';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_add_button'] = 'Añadir Servicio';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_save_button'] = 'Guardar Servicio';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_cancel_edit_button'] = 'Cancelar Edición';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_confirm_delete'] = '¿Estás seguro de que quieres eliminar este servicio?';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_icon_modal_title'] = 'Gestor de Iconos';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_icon_upload_new'] = 'Subir Nuevo Icono';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_icon_upload_button'] = 'Subir Icono';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_icon_uploaded_list'] = 'Iconos Subidos';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_icon_click_to_use'] = 'Clic para usar';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_no_icons_uploaded'] = 'No hay iconos subidos o no se pueden listar.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_error_loading_icons'] = 'Error al cargar los iconos.';
+$_MODULE['<{mlthemebuilder}prestashop>admin_services_error_loading_icons_ajax'] = 'Error AJAX al cargar los iconos.';
+
+
+// brands_manager.tpl (similar to services)
+$_MODULE['<{mlthemebuilder}prestashop>admin_brands_title_page'] = 'Gestionar Marcas/Logos de Socios';
+// ... (add all labels from brands_manager.tpl)
+
+// advanced_settings.tpl
+$_MODULE['<{mlthemebuilder}prestashop>admin_advanced_custom_codes_legend'] = 'Códigos Personalizados';
+// ... (add all labels from advanced_settings.tpl)
+
+// import_export.tpl
+$_MODULE['<{mlthemebuilder}prestashop>admin_importexport_export_legend'] = 'Exportar Configuración';
+// ... (add all labels from import_export.tpl)
+
+
+// Section Configuration Forms (hero.tpl, services.tpl, etc. in admin/sections/)
+// Hero Section
+$_MODULE['<{mlthemebuilder}prestashop>admin_section_hero_title_label'] = 'Título Principal';
+$_MODULE['<{mlthemebuilder}prestashop>admin_section_hero_title_help'] = 'Encabezado principal para la sección hero.';
+// ... (add all labels and help texts for hero section config form)
+
+// Services Section (admin/sections/services.tpl)
+$_MODULE['<{mlthemebuilder}prestashop>admin_section_services_title_label'] = 'Título de la Sección';
+// ... (add all labels for services section config form)
+
+// ... Add translations for all other section config forms ...
+// Products, Banner, Brands, Ecology, Contact, Custom HTML
+
+// Frontend section titles (defaults, can be overridden by user)
+$_MODULE['<{mlthemebuilder}prestashop>shop_hero_default_title'] = 'Bienvenido a Nuestra Tienda';
+$_MODULE['<{mlthemebuilder}prestashop>shop_services_default_title'] = 'Nuestros Servicios';
+$_MODULE['<{mlthemebuilder}prestashop>shop_products_default_title'] = 'Productos Destacados';
+$_MODULE['<{mlthemebuilder}prestashop>shop_banner_default_title'] = 'Oferta Especial';
+$_MODULE['<{mlthemebuilder}prestashop>shop_brands_default_title'] = 'Marcas de Confianza';
+$_MODULE['<{mlthemebuilder}prestashop>shop_ecology_default_title'] = 'Nuestro Compromiso Ecológico';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contact_default_title'] = 'Contáctanos';
+
+// Contact Form Frontend
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_name_placeholder'] = 'Tu Nombre';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_email_placeholder'] = 'Tu Email';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_message_placeholder'] = 'Tu Mensaje';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_send_button'] = 'Enviar Mensaje';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_sending'] = 'Enviando...';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_success'] = '¡Mensaje enviado con éxito!';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_error'] = 'Error al enviar el mensaje. Por favor, inténtalo de nuevo.';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_fill_required'] = 'Por favor, rellena todos los campos requeridos.';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_address_label'] = 'Dirección';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_phone_label'] = 'Teléfono';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_email_label'] = 'Email';
+$_MODULE['<{mlthemebuilder}prestashop>shop_contactform_hours_label'] = 'Horarios';
+
+
+// General shop texts that might be used in templates
+$_MODULE['<{mlthemebuilder}prestashop>shop_view_products_button'] = 'Ver Productos';
+$_MODULE['<{mlthemebuilder}prestashop>shop_view_category_button'] = 'Ver Categoría';
+$_MODULE['<{mlthemebuilder}prestashop>shop_no_products_found'] = 'No se encontraron productos para esta selección.';
+$_MODULE['<{mlthemebuilder}prestashop>shop_no_services_available'] = 'No hay servicios disponibles en este momento.';
+$_MODULE['<{mlthemebuilder}prestashop>shop_no_brands_available'] = 'No hay marcas para mostrar en este momento.';
+
+return $_MODULE;

--- a/modules/mlthemebuilder/translations/index.php
+++ b/modules/mlthemebuilder/translations/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/mlthemebuilder/upgrade/index.php
+++ b/modules/mlthemebuilder/upgrade/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/mlthemebuilder/upgrade/upgrade-1.0.1.php
+++ b/modules/mlthemebuilder/upgrade/upgrade-1.0.1.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * MlThemeBuilder Upgrade Script for version 1.0.1
+ *
+ * Example:
+ * - Add a new configuration field
+ * - Modify a database table (add a column, etc.)
+ * - Install a new hook
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Handles the upgrade to version 1.0.1 of the MlThemeBuilder module.
+ *
+ * @param MlThemeBuilder $module Instance of your module
+ * @return bool True if upgrade is successful, false otherwise.
+ */
+function upgrade_module_1_0_1($module)
+{
+    // Example: Add a new configuration value
+    // Configuration::updateValue('MLTHEME_NEW_FEATURE_ENABLED', 0);
+
+    // Example: Add a new column to an existing table
+    // $sql_addColumn = 'ALTER TABLE `' . _DB_PREFIX_ . 'mltheme_sections` ADD `new_column` VARCHAR(255) NULL DEFAULT NULL AFTER `config`;';
+    // if (!Db::getInstance()->execute($sql_addColumn)) {
+    //     // Log error or add to module errors
+    //     $module->addError('Failed to add new_column to mltheme_sections table.');
+    //     return false;
+    // }
+
+    // Example: Register a new hook
+    // if (!$module->registerHook('displayCustomHookName')) {
+    //     $module->addError('Failed to register hook displayCustomHookName.');
+    //     return false;
+    // }
+
+    // Example: Update an existing tab name or icon
+    // $id_tab = Tab::getIdFromClassName('AdminMlThemeBuilder');
+    // if ($id_tab) {
+    //     $tab = new Tab((int)$id_tab);
+    //     if (Validate::isLoadedObject($tab)) {
+    //         // $tab->icon = 'new-icon-class'; // Update icon
+    //         // foreach (Language::getLanguages(false) as $lang) {
+    //         //    $tab->name[(int)$lang['id_lang']] = $module->getTranslator()->trans('Theme Builder Enhanced', [], 'Modules.Mlthemebuilder.Admin');
+    //         // }
+    //         // if (!$tab->update()) {
+    //         //     $module->addError('Failed to update tab name/icon.');
+    //         //     return false;
+    //         // }
+    //     }
+    // }
+
+    // Always return true if all operations are successful.
+    // If any operation fails, log the error and return false.
+    // PrestaShop will then mark the upgrade as failed.
+
+    // For this initial setup, if no specific DB changes or actions are needed for 1.0.1,
+    // just returning true is fine.
+    // It's good practice to have these files for future versions.
+
+    // Clear cache after upgrade
+    $module->clearCache('*');
+
+    return true;
+}

--- a/modules/mlthemebuilder/views/css/admin.css
+++ b/modules/mlthemebuilder/views/css/admin.css
@@ -1,0 +1,337 @@
+/* Admin CSS for MlThemeBuilder - admin.css */
+
+/* General styles for the configuration page */
+#mlthemebuilder-config .panel-heading {
+    font-size: 1.4em;
+}
+#mlthemebuilder-config .nav-tabs > li > a {
+    font-weight: bold;
+    color: #337ab7; /* PrestaShop blue */
+}
+#mlthemebuilder-config .nav-tabs > li.active > a,
+#mlthemebuilder-config .nav-tabs > li.active > a:hover,
+#mlthemebuilder-config .nav-tabs > li.active > a:focus {
+    color: #555;
+    background-color: #fff;
+    border: 1px solid #ddd;
+    border-bottom-color: transparent;
+}
+#mlthemebuilder-config .tab-content {
+    padding: 20px;
+    border: 1px solid #ddd;
+    border-top: none;
+    background-color: #fff;
+}
+
+/* Sections Manager Styles */
+.sections-container {
+    margin-top: 20px;
+    margin-bottom: 30px;
+}
+.section-item, .service-item, .brand-item-admin { /* Shared styling for draggable items */
+    background: #f9f9f9;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    margin-bottom: 10px;
+    padding: 12px 15px;
+    transition: all 0.2s ease-in-out;
+    display: flex; /* Use flex for better alignment */
+    justify-content: space-between;
+    align-items: center;
+}
+.section-item:hover, .service-item:hover, .brand-item-admin:hover {
+    box-shadow: 0 3px 8px rgba(0,0,0,0.1);
+    border-color: #ccc;
+}
+
+.section-header { /* This class was used inside section-item in user HTML, adapting */
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%; /* Ensure it takes full width of parent flex item */
+}
+
+.section-info, .service-info, .brand-info { /* Shared */
+    display: flex;
+    align-items: center;
+    gap: 12px; /* Space between icon and text */
+    flex-grow: 1; /* Allow text to take available space */
+    overflow: hidden; /* Prevent long names from breaking layout */
+}
+.drag-handle {
+    cursor: move;
+    color: #777;
+    font-size: 1.3em;
+    padding-right: 5px;
+}
+.section-name, .service-name, .brand-name-admin { /* Shared */
+    font-weight: 600;
+    color: #333;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.section-type { /* Specific to sections */
+    background: #667eea; /* Module primary color */
+    color: white;
+    font-size: 0.8rem;
+    padding: 3px 8px;
+    border-radius: 4px;
+    font-weight: normal;
+    margin-left: 5px;
+}
+.service-icon-preview i, .brand-logo-preview img {
+    vertical-align: middle;
+}
+.brand-logo-preview img {
+    max-height: 24px;
+    max-width: 80px;
+    border: 1px solid #eee;
+    background-color: #fff;
+}
+
+
+.section-controls, .service-controls, .brand-controls { /* Shared */
+    display: flex;
+    align-items: center;
+    gap: 10px; /* Space between buttons/switch */
+}
+.section-controls .btn, .service-controls .btn, .brand-controls .btn {
+    padding: 5px 10px; /* Smaller buttons for admin */
+    font-size: 0.9em;
+}
+
+.section-preview {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px dashed #eee;
+    font-size: 0.85em;
+    color: #777;
+    width: 100%; /* Span full width below header */
+    flex-basis: 100%; /* For flex items, ensure it takes its own line if header is flex */
+}
+
+/* Sortable List Placeholders */
+.sortable-list {
+    min-height: 80px; /* Visual cue for empty list */
+    border: 1px dashed #ccc;
+    padding: 10px;
+    border-radius: 4px;
+    background-color: #fdfdfd;
+}
+.ui-sortable-helper { /* While dragging */
+    box-shadow: 0 5px 15px rgba(0,0,0,0.2);
+    transform: rotate(1deg) scale(1.02);
+    opacity: 0.9;
+    background-color: #fff !important; /* Ensure helper is clearly visible */
+    border: 1px solid #aaa;
+}
+.ui-sortable-placeholder {
+    background: #e8f0fe !important; /* Light blue placeholder */
+    border: 2px dashed #667eea !important;
+    border-radius: 6px !important;
+    height: 50px; /* Match item height approx */
+    margin-bottom: 10px;
+    visibility: visible !important; /* Ensure placeholder is always visible */
+}
+
+/* Form elements in tabs */
+#mlthemebuilder-config fieldset {
+    margin-bottom: 25px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid #eee;
+}
+#mlthemebuilder-config fieldset:last-of-type {
+    border-bottom: none;
+    margin-bottom: 0;
+}
+#mlthemebuilder-config fieldset legend {
+    font-size: 1.1em;
+    font-weight: bold;
+    color: #444;
+    border-bottom: none; /* Remove PS default legend border */
+    margin-bottom: 15px;
+}
+#mlthemebuilder-config .form-group {
+    margin-bottom: 18px;
+}
+#mlthemebuilder-config .color-picker {
+    min-width: 80px; /* Ensure color picker is usable */
+    max-width: 120px;
+    height: 34px !important; /* Override PS default if needed */
+    padding: 2px !important; /* Adjust padding for color type */
+    border-radius: 4px;
+    cursor: pointer;
+    border: 1px solid #ccc;
+}
+#mlthemebuilder-config .help-block {
+    font-size: 0.9em;
+    color: #777;
+}
+#mlthemebuilder-config textarea.form-control {
+    min-height: 120px;
+    font-family: monospace;
+    font-size: 0.95em;
+}
+
+/* Modal Styling */
+#sectionConfigurationModal .modal-dialog {
+    width: 70%; /* Wider modal for complex forms */
+    max-width: 900px;
+}
+#sectionConfigurationModal .modal-title {
+    font-weight: bold;
+}
+#sectionConfigurationModal .modal-body {
+    max-height: 70vh;
+    overflow-y: auto;
+}
+#sectionConfigurationModal .modal-body .form-group {
+    display: flex;
+    flex-wrap: wrap; /* Allow label and input to wrap on small screens */
+    align-items: flex-start; /* Align label top with input */
+    margin-bottom: 15px;
+}
+#sectionConfigurationModal .modal-body .control-label {
+    flex-basis: 200px; /* Fixed width for labels */
+    margin-right: 15px;
+    text-align: right;
+    padding-top: 7px; /* Align with input text */
+}
+#sectionConfigurationModal .modal-body .form-control,
+#sectionConfigurationModal .modal-body .input-group,
+#sectionConfigurationModal .modal-body .prestashop-switch {
+    flex-grow: 1; /* Input takes remaining space */
+    max-width: calc(100% - 215px); /* Account for label and gap */
+}
+#sectionConfigurationModal .modal-body .translations .tab-content {
+    padding: 15px;
+    border: 1px solid #ddd;
+    border-top: none;
+    margin-bottom: 15px;
+}
+#sectionConfigurationModal .modal-body .img-thumbnail {
+    max-height: 80px;
+    margin-top: 5px;
+    margin-right: 5px;
+}
+#sectionConfigurationModal .remove-image-btn {
+    vertical-align: top;
+    margin-left: 5px;
+}
+
+/* Icon Manager Modal */
+#iconManagerModal .uploaded-icon-item {
+    display: inline-block;
+    padding: 10px;
+    margin: 5px;
+    border: 1px solid #eee;
+    border-radius: 4px;
+    text-align: center;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+#iconManagerModal .uploaded-icon-item:hover {
+    background-color: #f0f0f0;
+}
+#iconManagerModal .uploaded-icon-item img {
+    max-width: 40px;
+    max-height: 40px;
+    display: block;
+    margin: 0 auto 5px;
+}
+#iconManagerModal .uploaded-icon-item span {
+    font-size: 0.8em;
+    color: #555;
+    word-break: break-all;
+}
+
+
+/* Specific for Services/Brands Manager forms if they are simple */
+#serviceForm .form-group .input-group-addon i,
+#brandForm .form-group .input-group-addon i { /* Icon preview in input group */
+    font-size: 1.2em;
+}
+
+/* Import/Export Tab */
+#importResult .alert {
+    margin-top: 15px;
+}
+
+/* Helper for language fields in forms (like service/brand titles) */
+.dropdown-menu {
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+/* Ensure consistent switch styling */
+.prestashop-switch {
+    min-width: 70px; /* Ensure enough space for Yes/No */
+}
+
+/* Tooltips for better UX */
+.label-tooltip {
+    cursor: help;
+}
+
+/* Image upload previews */
+.image-upload-preview {
+    max-width: 200px;
+    max-height: 100px;
+    border: 1px solid #ddd;
+    padding: 5px;
+    margin-top: 10px;
+    border-radius: 4px;
+    background-color: #f9f9f9;
+}
+.image-upload-preview.hidden {
+    display: none;
+}
+
+/* Add some spacing for clarity in complex forms */
+.form-section-divider {
+    margin-top: 20px;
+    margin-bottom: 20px;
+    border-top: 1px solid #eee;
+}
+
+/* Styling for repeatable items (like ecology items in section config) */
+.repeatable-item-container .repeatable-item {
+    border: 1px solid #e0e0e0;
+    padding: 15px;
+    margin-bottom: 10px;
+    border-radius: 4px;
+    background-color: #fdfdfd;
+}
+.repeatable-item-container .repeatable-item-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+.repeatable-item-container .repeatable-item-header h5 {
+    margin: 0;
+    font-size: 1em;
+    font-weight: bold;
+}
+.repeatable-item-container .remove-repeatable-item {
+    color: #d9534f; /* Danger color */
+    cursor: pointer;
+}
+.repeatable-item-container .add-repeatable-item {
+    margin-top: 10px;
+}
+
+/* Responsive adjustments for admin if needed */
+@media (max-width: 767px) {
+    #sectionConfigurationModal .modal-body .control-label {
+        flex-basis: 100%; /* Stack label on top */
+        text-align: left;
+        margin-bottom: 5px;
+    }
+    #sectionConfigurationModal .modal-body .form-control,
+    #sectionConfigurationModal .modal-body .input-group,
+    #sectionConfigurationModal .modal-body .prestashop-switch {
+        max-width: 100%;
+    }
+}

--- a/modules/mlthemebuilder/views/css/animations.css
+++ b/modules/mlthemebuilder/views/css/animations.css
@@ -1,0 +1,224 @@
+/* CSS Adicional para MlThemeBuilder - Animaciones y Efectos (animations.css) */
+
+/* Variables CSS (pueden ser usadas por el módulo, pero se definen aquí para animaciones específicas) */
+:root {
+    --ml-anim-primary-color: #667eea; /* Heredar de front.css o definir si es diferente */
+    --ml-anim-secondary-color: #ff6b6b;
+    --ml-anim-transition-duration: 0.6s; /* Duración base para animaciones de entrada */
+    --ml-anim-transition-timing: ease; /* Timing base */
+}
+
+/* --- Animaciones de Entrada Generales --- */
+@keyframes ml-fadeInUp {
+    from { opacity: 0; transform: translateY(40px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+@keyframes ml-fadeInDown {
+    from { opacity: 0; transform: translateY(-40px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+@keyframes ml-fadeInLeft {
+    from { opacity: 0; transform: translateX(-50px); }
+    to { opacity: 1; transform: translateX(0); }
+}
+@keyframes ml-fadeInRight {
+    from { opacity: 0; transform: translateX(50px); }
+    to { opacity: 1; transform: translateX(0); }
+}
+@keyframes ml-scaleIn {
+    from { opacity: 0; transform: scale(0.85); }
+    to { opacity: 1; transform: scale(1); }
+}
+@keyframes ml-zoomIn { /* Más sutil que scaleIn */
+    from { opacity: 0; transform: scale(0.95); }
+    to { opacity: 1; transform: scale(1); }
+}
+
+/* Clases de utilidad para aplicar animaciones (usadas por JS con IntersectionObserver) */
+.ml-animate-on-scroll {
+    opacity: 0; /* Oculto hasta que JS lo active */
+    transition: opacity var(--ml-anim-transition-duration) var(--ml-anim-transition-timing),
+                transform var(--ml-anim-transition-duration) var(--ml-anim-transition-timing);
+}
+.ml-animate-on-scroll.is-visible {
+    opacity: 1;
+}
+
+/* Aplicar la animación específica cuando el elemento es visible */
+.ml-animate-on-scroll.is-visible.anim-fadeInUp { animation: ml-fadeInUp var(--ml-anim-transition-duration) var(--ml-anim-transition-timing) forwards; }
+.ml-animate-on-scroll.is-visible.anim-fadeInDown { animation: ml-fadeInDown var(--ml-anim-transition-duration) var(--ml-anim-transition-timing) forwards; }
+.ml-animate-on-scroll.is-visible.anim-fadeInLeft { animation: ml-fadeInLeft var(--ml-anim-transition-duration) var(--ml-anim-transition-timing) forwards; }
+.ml-animate-on-scroll.is-visible.anim-fadeInRight { animation: ml-fadeInRight var(--ml-anim-transition-duration) var(--ml-anim-transition-timing) forwards; }
+.ml-animate-on-scroll.is-visible.anim-scaleIn { animation: ml-scaleIn var(--ml-anim-transition-duration) var(--ml-anim-transition-timing) forwards; }
+.ml-animate-on-scroll.is-visible.anim-zoomIn { animation: ml-zoomIn var(--ml-anim-transition-duration) var(--ml-anim-transition-timing) forwards; }
+
+/* Para animaciones con delay escalonado (manejado por JS) */
+.ml-stagger-delay-1.is-visible { transition-delay: 0.1s; animation-delay: 0.1s; }
+.ml-stagger-delay-2.is-visible { transition-delay: 0.2s; animation-delay: 0.2s; }
+.ml-stagger-delay-3.is-visible { transition-delay: 0.3s; animation-delay: 0.3s; }
+.ml-stagger-delay-4.is-visible { transition-delay: 0.4s; animation-delay: 0.4s; }
+
+
+/* --- Animaciones Continuas --- */
+@keyframes ml-pulse {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(1.05); }
+}
+.anim-pulse { animation: ml-pulse 2s infinite ease-in-out; }
+
+@keyframes ml-float {
+    0%, 100% { transform: translateY(0px); }
+    50% { transform: translateY(-12px); }
+}
+.anim-float { animation: ml-float 3.5s infinite ease-in-out; }
+
+@keyframes ml-shake { /* Sutil temblor */
+    0%, 100% { transform: translateX(0); }
+    25% { transform: translateX(-3px); }
+    50% { transform: translateX(3px); }
+    75% { transform: translateX(-2px); }
+}
+.anim-shake-hover:hover { animation: ml-shake 0.4s ease-in-out; }
+
+
+/* --- Efectos de Hover --- */
+.ml-hover-lift {
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+.ml-hover-lift:hover {
+    transform: translateY(-8px);
+    box-shadow: 0 15px 35px rgba(0,0,0,0.12);
+}
+
+.ml-hover-scale {
+    transition: transform 0.3s ease;
+}
+.ml-hover-scale:hover {
+    transform: scale(1.05);
+}
+
+.ml-hover-glow { /* Sutil brillo al hacer hover */
+    transition: box-shadow 0.3s ease;
+}
+.ml-hover-glow:hover {
+    box-shadow: 0 0 20px rgba(var(--ml-primary-color-rgb, 102,126,234), 0.5); /* Asume que --ml-primary-color-rgb está definido */
+}
+
+
+/* --- Efecto Ripple para Botones (si se usa CSS puro) --- */
+.btn.ml-ripple-effect {
+    position: relative;
+    overflow: hidden;
+}
+.btn.ml-ripple-effect .ripple {
+    position: absolute;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.3); /* Color del ripple */
+    transform: scale(0);
+    animation: ml-ripple-animation 0.6s linear;
+    pointer-events: none; /* Importante */
+}
+@keyframes ml-ripple-animation {
+    to {
+        transform: scale(4); /* Ajustar según tamaño del botón */
+        opacity: 0;
+    }
+}
+
+/* --- Animación de Scroll para Slider de Marcas (si es CSS puro) --- */
+/* Esto es un ejemplo, el JS puede manejarlo de forma más robusta */
+/* .brands-section .brands-track.css-animated {
+    animation: ml-scroll-brands var(--scroll-duration, 30s) linear infinite;
+}
+@keyframes ml-scroll-brands {
+    0% { transform: translateX(0); }
+    100% { transform: translateX(-50%); } /* Asume que el track se duplicó para el efecto infinito */
+/* } */
+/* .brands-section .brands-track.css-animated:hover {
+    animation-play-state: paused;
+} */
+
+
+/* --- Estados de Carga y Esqueletos (Skeletons) --- */
+.ml-loading-shimmer::after { /* Para efecto shimmer en elementos de carga */
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -150%; /* Inicia fuera de la vista */
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(255,255,255,0.25), transparent);
+    animation: ml-loading-shimmer-anim 1.8s infinite;
+}
+@keyframes ml-loading-shimmer-anim {
+    100% { left: 150%; /* Termina fuera de la vista en el otro lado */ }
+}
+
+.ml-skeleton { /* Clase base para un elemento esqueleto */
+    background-color: #e0e0e0; /* Color base del esqueleto */
+    border-radius: 4px;
+    position: relative; /* Para el shimmer */
+    overflow: hidden; /* Para el shimmer */
+}
+.ml-skeleton-text { height: 1em; margin-bottom: 0.5em; }
+.ml-skeleton-text:last-child { width: 70%; }
+.ml-skeleton-title { height: 1.5em; width: 50%; margin-bottom: 0.75em; }
+.ml-skeleton-avatar { width: 50px; height: 50px; border-radius: 50%; }
+.ml-skeleton-image { width: 100%; padding-bottom: 75%; /* Aspect ratio 4:3 */ background-color: #e0e0e0; }
+
+
+/* --- Parallax Suave (si se usa CSS para un efecto simple) --- */
+/* Un parallax más complejo usualmente requiere JS */
+.ml-parallax-bg {
+    background-attachment: fixed; /* Efecto parallax clásico, pero limitado */
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+}
+.ml-parallax-element { /* Para elementos individuales con parallax */
+    transition: transform 0.2s ease-out; /* Para suavizar el movimiento JS */
+    will-change: transform; /* Optimización */
+}
+
+/* --- Soporte para Movimiento Reducido --- */
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        animation-play-state: paused !important; /* Detener animaciones continuas */
+    }
+    .ml-animate-on-scroll { /* Mostrar directamente sin animar */
+        opacity: 1;
+        transform: none;
+    }
+    .anim-pulse, .anim-float { animation: none; }
+}
+
+/* --- Efectos de Transición de Página (si se implementan) --- */
+.page-transition-fade-out {
+    animation: ml-fadeOut 0.5s ease forwards;
+}
+.page-transition-fade-in {
+    animation: ml-fadeIn 0.5s ease forwards;
+}
+@keyframes ml-fadeOut {
+    to { opacity: 0; visibility: hidden; }
+}
+@keyframes ml-fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+/* Utilidades de GPU Acceleration (pueden ayudar con el rendimiento de animaciones) */
+.gpu-accelerate {
+    transform: translateZ(0);
+    backface-visibility: hidden;
+    -webkit-font-smoothing: subpixel-antialiased; /* Para texto más nítido en Webkit */
+}
+
+/* Definir --ml-primary-color-rgb si no lo hace front.css, para el hover glow */
+/* Se puede hacer en JS o en el <style> del header.tpl si los colores son dinámicos */
+/* body {
+    --ml-primary-color-rgb: 102,126,234; /* Ejemplo para #667eea */
+/* } */

--- a/modules/mlthemebuilder/views/css/front.css
+++ b/modules/mlthemebuilder/views/css/front.css
@@ -1,0 +1,661 @@
+/* CSS Base para el MlThemeBuilder - front.css */
+
+/* Variables CSS Globales (serán sobreescritas por configuración del módulo si aplica) */
+:root {
+    --ml-primary-color: #667eea; /* Default, can be overridden by MlThemeSetting */
+    --ml-secondary-color: #ff6b6b; /* Default */
+    --ml-text-color: #333333; /* Default */
+    --ml-link-color: var(--ml-primary-color); /* Default */
+    --ml-bg-light-color: #f8f9fa; /* Default */
+    --ml-bg-dark-color: #333333; /* Default */
+    --ml-font-primary: 'Arial', sans-serif; /* Default */
+    --ml-font-secondary: var(--ml-font-primary); /* Default */
+    --ml-base-font-size: 16px; /* Default */
+    --ml-heading-font-scale: 1.2; /* Default */
+    --ml-container-max-width: 1200px; /* Default */
+    --ml-section-padding-y: 60px; /* Default */
+    --ml-button-border-radius: 8px; /* Default */
+
+    --ml-shadow: 0 10px 30px rgba(0,0,0,0.1);
+    --ml-shadow-hover: 0 15px 40px rgba(0,0,0,0.15);
+    --ml-transition: all 0.3s ease;
+    --ml-border-radius-cards: 15px; /* Specific for cards */
+}
+
+/* Estilos base del body si son controlados por el módulo */
+body.mltheme-active { /* Clase que se podría añadir al body si el módulo está activo */
+    font-family: var(--ml-font-primary);
+    font-size: var(--ml-base-font-size);
+    color: var(--ml-text-color);
+    line-height: 1.6;
+    background-color: var(--ml-bg-light-color); /* O un color de fondo general */
+}
+
+/* Contenedor principal para secciones */
+.mltheme-section .container {
+    max-width: var(--ml-container-max-width);
+    margin: 0 auto;
+    padding: 0 20px; /* Padding lateral estándar */
+}
+
+/* Estilos generales para todas las secciones del módulo */
+.mltheme-section {
+    padding-top: var(--ml-section-padding-y);
+    padding-bottom: var(--ml-section-padding-y);
+    overflow: hidden; /* Para contener elementos flotantes o con márgenes negativos */
+}
+
+.mltheme-section .section-header {
+    text-align: center;
+    margin-bottom: 60px;
+}
+
+.mltheme-section .section-title {
+    font-family: var(--ml-font-secondary);
+    /* H2 size: base * scale^4, H1: base*scale^5 etc. (typical modular scale) */
+    font-size: calc(var(--ml-base-font-size) * var(--ml-heading-font-scale) * var(--ml-heading-font-scale) * var(--ml-heading-font-scale) * var(--ml-heading-font-scale));
+    font-weight: 600;
+    color: var(--ml-text-color); /* O un color específico para títulos */
+    margin-bottom: 15px;
+}
+
+.mltheme-section .section-subtitle {
+    font-size: calc(var(--ml-base-font-size) * 1.15); /* Ligeramente más grande que el texto base */
+    color: var(--ml-text-light, #666); /* Usar variable si existe, sino fallback */
+    max-width: 700px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+/* Estilos de Botones Genéricos (pueden ser extendidos por botones específicos de sección) */
+.btn {
+    display: inline-block;
+    padding: 12px 24px;
+    text-decoration: none;
+    border-radius: var(--ml-button-border-radius);
+    font-weight: 600;
+    text-align: center;
+    transition: var(--ml-transition);
+    border: none;
+    cursor: pointer;
+    font-size: calc(var(--ml-base-font-size) * 0.95); /* Un poco más pequeño o igual al base */
+    line-height: 1.5;
+}
+
+.btn-primary {
+    background-color: var(--ml-primary-color);
+    color: white; /* Asumir texto blanco para colores primarios oscuros */
+}
+.btn-primary:hover {
+    background-color: color-mix(in srgb, var(--ml-primary-color) 85%, black); /* Oscurecer un poco */
+    transform: translateY(-2px);
+    box-shadow: var(--ml-shadow-hover);
+}
+
+.btn-secondary {
+    background-color: var(--ml-secondary-color);
+    color: white; /* Asumir texto blanco */
+}
+.btn-secondary:hover {
+    background-color: color-mix(in srgb, var(--ml-secondary-color) 85%, black);
+    transform: translateY(-2px);
+    box-shadow: var(--ml-shadow-hover);
+}
+
+.btn-outline {
+    background: transparent;
+    border: 2px solid var(--ml-primary-color);
+    color: var(--ml-primary-color);
+}
+.btn-outline:hover {
+    background: var(--ml-primary-color);
+    color: white;
+}
+
+
+/* --- Hero Section --- */
+.hero-section {
+    /* background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); */ /* Ejemplo, será por config */
+    color: white; /* Generalmente texto blanco sobre fondos oscuros/coloridos */
+    /* padding: 100px 0; */ /* Usa var(--ml-section-padding-y) o específico */
+    min-height: 600px; /* Configurable */
+    display: flex;
+    align-items: center;
+    position: relative;
+}
+.hero-section .hero-container { /* Hereda de .container */ }
+.hero-section .hero-content {
+    display: grid;
+    grid-template-columns: 1fr 1fr; /* Default, puede cambiar por config */
+    gap: 60px;
+    align-items: center;
+    position: relative;
+    z-index: 2;
+}
+.hero-section.layout-text_left_image_right .hero-content { grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); }
+.hero-section.layout-image_left_text_right .hero-content { grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); }
+.hero-section.layout-image_left_text_right .hero-text { order: 2; }
+.hero-section.layout-image_left_text_right .hero-image { order: 1; }
+
+.hero-section.layout-text_center_image_background .hero-content,
+.hero-section.layout-text_center_no_image .hero-content {
+    grid-template-columns: 1fr;
+    text-align: center;
+}
+.hero-section.layout-text_center_image_background .hero-image,
+.hero-section.layout-text_center_no_image .hero-image {
+    display: none; /* La imagen principal se usa como fondo de la sección */
+}
+.hero-section.layout-text_center_image_background {
+    background-size: cover;
+    background-position: center center;
+}
+
+
+.hero-section .hero-title {
+    font-family: var(--ml-font-secondary);
+    font-size: calc(var(--ml-base-font-size) * var(--ml-heading-font-scale) * var(--ml-heading-font-scale) * var(--ml-heading-font-scale) * var(--ml-heading-font-scale) * var(--ml-heading-font-scale)); /* H1 */
+    font-weight: 700;
+    margin-bottom: 20px;
+    line-height: 1.2;
+    color: inherit; /* Hereda de .hero-section */
+}
+.hero-section .hero-subtitle {
+    font-size: calc(var(--ml-base-font-size) * 1.3));
+    margin-bottom: 30px;
+    opacity: 0.9;
+    color: inherit;
+}
+.hero-section .hero-btn { /* Estilos adicionales específicos si es necesario */
+    /* background: #ff6b6b; */ /* Ejemplo, usa btn-primary o btn-secondary */
+    padding: 15px 30px;
+    font-size: calc(var(--ml-base-font-size) * 1.05);
+    /* border-radius: 30px; */ /* Usa var(--ml-button-border-radius) */
+}
+.hero-section .hero-img {
+    width: 100%;
+    max-width: 500px; /* Evita que la imagen sea demasiado grande */
+    border-radius: var(--ml-border-radius-cards);
+    box-shadow: var(--ml-shadow);
+}
+.hero-section.layout-text_center_image_background .hero-img { display: none; }
+
+
+/* --- Services Section --- */
+.services-section {
+    background: var(--ml-bg-light-color); /* O color de config */
+}
+.services-section .services-grid {
+    display: grid;
+    /* grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gestionado por clase columns-X */
+    gap: 30px;
+}
+.services-section .services-grid.columns-2 { grid-template-columns: repeat(auto-fit, minmax(min(100%, 400px), 1fr)); }
+.services-section .services-grid.columns-3 { grid-template-columns: repeat(auto-fit, minmax(min(100%, 300px), 1fr)); }
+.services-section .services-grid.columns-4 { grid-template-columns: repeat(auto-fit, minmax(min(100%, 250px), 1fr)); }
+
+.services-section .service-card {
+    background: white; /* O color de config */
+    padding: 40px 30px;
+    border-radius: var(--ml-border-radius-cards);
+    text-align: center;
+    box-shadow: var(--ml-shadow);
+    transition: var(--ml-transition);
+}
+.services-section .service-card:hover {
+    transform: translateY(-5px);
+    box-shadow: var(--ml-shadow-hover);
+}
+.services-section .service-icon {
+    font-size: 3rem; /* Configurable? */
+    color: var(--ml-primary-color); /* Configurable? */
+    margin-bottom: 20px;
+}
+.services-section .service-icon-img {
+    max-height: 50px;
+    max-width: 50px;
+    margin-bottom: 20px;
+}
+.services-section .service-title {
+    font-family: var(--ml-font-secondary);
+    font-size: calc(var(--ml-base-font-size) * var(--ml-heading-font-scale)); /* H3 */
+    font-weight: 600;
+    color: var(--ml-text-color);
+    margin-bottom: 15px;
+}
+.services-section .service-description {
+    color: var(--ml-text-light, #666);
+    line-height: 1.6;
+    font-size: calc(var(--ml-base-font-size) * 0.9);
+}
+
+
+/* --- Products Section --- */
+.products-section { /* Sin fondo por defecto, usa el del body o config */ }
+.products-section .categories-grid {
+    display: grid;
+    /* grid-template-columns: repeat(auto-fit, minmax(350px, 1fr)); */
+    gap: 30px;
+}
+.products-section .categories-grid.columns-2 { grid-template-columns: repeat(auto-fit, minmax(min(100%, 450px), 1fr)); }
+.products-section .categories-grid.columns-3 { grid-template-columns: repeat(auto-fit, minmax(min(100%, 350px), 1fr)); }
+.products-section .categories-grid.columns-4 { grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr)); }
+
+.products-section .category-card {
+    background: white; /* O config */
+    border-radius: var(--ml-border-radius-cards);
+    overflow: hidden;
+    box-shadow: var(--ml-shadow);
+    transition: var(--ml-transition);
+}
+.products-section .category-card:hover {
+    transform: translateY(-5px);
+    box-shadow: var(--ml-shadow-hover);
+}
+.products-section .category-image {
+    height: 200px; /* Configurable? */
+    overflow: hidden;
+}
+.products-section .category-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+.products-section .category-content {
+    padding: 30px;
+}
+.products-section .category-title {
+    font-family: var(--ml-font-secondary);
+    font-size: calc(var(--ml-base-font-size) * var(--ml-heading-font-scale)); /* H3 */
+    font-weight: 600;
+    color: var(--ml-text-color);
+    margin-bottom: 15px;
+}
+.products-section .category-title a {
+    text-decoration: none;
+    color: inherit;
+}
+.products-section .category-title a:hover {
+    color: var(--ml-link-color);
+}
+.products-section .subcategories {
+    margin-bottom: 20px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+.products-section .subcategory-link {
+    display: inline-block;
+    padding: 5px 12px;
+    background: var(--ml-bg-light-color);
+    color: var(--ml-text-light, #666);
+    text-decoration: none;
+    border-radius: 20px; /* Configurable? */
+    font-size: calc(var(--ml-base-font-size) * 0.85);
+    transition: var(--ml-transition);
+}
+.products-section .subcategory-link:hover {
+    background: var(--ml-primary-color);
+    color: white;
+}
+.products-section .category-btn { /* Hereda de .btn y .btn-outline */ }
+
+.products-section .products-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); /* Ajustar según diseño de product_item.tpl */
+    gap: 30px;
+}
+.products-section .section-footer-link {
+    margin-top: 40px;
+    text-align: center;
+}
+
+
+/* --- Banner CTA Section --- */
+.banner-cta-section {
+    /* background: linear-gradient(135deg, #ff6b6b 0%, #ffa726 100%); */ /* Ejemplo, config */
+    color: white; /* Generalmente */
+    background-size: cover;
+    background-position: center center;
+}
+.banner-cta-section .banner-container { /* Hereda de .container */ }
+.banner-cta-section .banner-content {
+    display: grid;
+    grid-template-columns: 1fr 1fr; /* Default: text left, image right */
+    gap: 60px;
+    align-items: center;
+}
+.banner-cta-section .banner-content.image-left .banner-text { order: 2; }
+.banner-cta-section .banner-content.image-left .banner-image { order: 1; }
+.banner-cta-section .banner-content.text_only { grid-template-columns: 1fr; text-align: center; }
+.banner-cta-section .banner-content.text_only .banner-image { display: none; }
+.banner-cta-section .banner-content.image_background { grid-template-columns: 1fr; text-align: center; }
+.banner-cta-section .banner-content.image_background .banner-image { display: none; } /* Imagen de contenido se oculta, se usa la de fondo de sección */
+
+
+.banner-cta-section .banner-title {
+    font-family: var(--ml-font-secondary);
+    font-size: calc(var(--ml-base-font-size) * var(--ml-heading-font-scale) * var(--ml-heading-font-scale)); /* H2 */
+    font-weight: 600;
+    margin-bottom: 20px;
+    color: inherit;
+}
+.banner-cta-section .banner-description {
+    font-size: calc(var(--ml-base-font-size) * 1.2);
+    margin-bottom: 30px;
+    opacity: 0.9;
+    color: inherit;
+}
+.banner-cta-section .banner-btn { /* Hereda de .btn y .btn-secondary */
+    /* background: white; color: #333; */ /* Ejemplo, config */
+    /* font-weight: 600; */
+}
+.banner-cta-section .banner-img {
+    width: 100%;
+    max-width: 450px;
+    border-radius: var(--ml-border-radius-cards);
+    box-shadow: var(--ml-shadow);
+}
+
+/* --- Brands Section --- */
+.brands-section {
+    background: var(--ml-bg-light-color); /* O config */
+}
+.brands-section .brands-slider {
+    overflow: hidden;
+    width: 100%;
+    position: relative; /* Para máscaras si se usan */
+}
+.brands-section .brands-track {
+    display: flex;
+    /* animation: scroll 30s linear infinite; gestionado por JS o config */
+    width: fit-content; /* Para que el JS pueda duplicar y medir */
+}
+.brands-section .brand-item {
+    flex: 0 0 auto; /* No crecer, no encoger, base automática */
+    margin: 0 30px; /* Espaciado entre logos, configurable? */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 80px; /* Altura fija para alinear logos, configurable? */
+}
+.brands-section .brand-logo {
+    max-height: 60px; /* Configurable? */
+    width: auto;
+    max-width: 150px; /* Configurable? */
+    filter: grayscale(100%);
+    opacity: 0.7;
+    transition: var(--ml-transition);
+}
+.brands-section .brand-logo:hover {
+    filter: grayscale(0%);
+    opacity: 1;
+    transform: scale(1.1);
+}
+.brands-section .brand-name { /* Fallback si no hay logo */
+    font-weight: 600;
+    color: var(--ml-text-light, #666);
+}
+/* Keyframes para scroll infinito CSS (si no se usa JS para el slider) */
+/* @keyframes ml-scroll-brands {
+    0% { transform: translateX(0); }
+    100% { transform: translateX(-50%); } /* Asume duplicación de elementos para scroll infinito */
+/* } */
+
+
+/* --- Ecology Section --- */
+.ecology-section {
+    /* background: #e8f5e8; */ /* Ejemplo, config */
+}
+.ecology-section .ecology-content {
+    display: grid;
+    grid-template-columns: 1fr 1fr; /* Default, config */
+    gap: 60px;
+    align-items: center;
+}
+.ecology-section .ecology-content.image-left .ecology-text { order: 2; }
+.ecology-section .ecology-content.image-left .ecology-image { order: 1; }
+
+.ecology-section .ecology-title {
+    font-family: var(--ml-font-secondary);
+    font-size: calc(var(--ml-base-font-size) * var(--ml-heading-font-scale) * var(--ml-heading-font-scale)); /* H2 */
+    font-weight: 600;
+    /* color: #2d5a3d; */ /* Ejemplo, config */
+    color: var(--ml-text-color);
+    margin-bottom: 20px;
+}
+.ecology-section .ecology-description {
+    font-size: calc(var(--ml-base-font-size) * 1.1);
+    /* color: #4a6741; */ /* Ejemplo, config */
+    color: var(--ml-text-light, #666);
+    margin-bottom: 30px;
+    line-height: 1.7;
+}
+.ecology-section .ecology-items {
+    display: flex;
+    flex-direction: column;
+    gap: 20px; /* Espacio entre items */
+    margin-bottom: 30px;
+}
+.ecology-section .ecology-item {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    font-size: calc(var(--ml-base-font-size) * 1.05);
+    /* color: #4a6741; */ /* config */
+    color: var(--ml-text-color);
+}
+.ecology-section .ecology-item i { /* Para FontAwesome */
+    /* color: #2d5a3d; */ /* config */
+    color: var(--ml-primary-color);
+    font-size: 1.5rem; /* Tamaño del icono */
+    width: 25px; /* Para alinear texto si los iconos varían de ancho */
+    text-align: center;
+}
+.ecology-section .ecology-item-icon { /* Para imágenes de icono */
+    max-height: 24px;
+    max-width: 24px;
+}
+.ecology-section .ecology-img {
+    width: 100%;
+    max-width: 500px;
+    border-radius: var(--ml-border-radius-cards);
+    box-shadow: var(--ml-shadow);
+}
+.ecology-section .ecology-button {
+    margin-top: 30px;
+}
+
+
+/* --- Contact Section --- */
+.contact-section {
+    background: var(--ml-bg-dark-color); /* Ejemplo, config */
+    color: white; /* Generalmente texto blanco sobre fondos oscuros */
+}
+.contact-section .section-title { color: white; } /* Sobreescribir color de título general */
+.contact-section .section-subtitle { color: rgba(255,255,255,0.8); }
+
+.contact-section .contact-content {
+    display: grid;
+    grid-template-columns: 1fr 1fr; /* Configurable? */
+    gap: 60px;
+}
+.contact-section .contact-info {
+    display: flex;
+    flex-direction: column;
+    gap: 30px; /* Espacio entre items de contacto */
+}
+.contact-section .contact-item {
+    display: flex;
+    align-items: flex-start; /* Alinear icono arriba con texto de varias líneas */
+    gap: 20px;
+}
+.contact-section .contact-item i { /* FontAwesome */
+    color: var(--ml-primary-color); /* Configurable? */
+    font-size: 1.5rem;
+    margin-top: 5px; /* Alinear con primera línea de texto */
+    width: 25px;
+    text-align: center;
+}
+.contact-section .contact-item h4 {
+    font-family: var(--ml-font-secondary);
+    font-size: calc(var(--ml-base-font-size) * 1.2);
+    font-weight: 600;
+    margin-bottom: 8px;
+    color: white; /* O config */
+}
+.contact-section .contact-item p {
+    color: rgba(255,255,255,0.8); /* O config */
+    line-height: 1.5;
+    font-size: var(--ml-base-font-size);
+}
+.contact-section .contact-item p a {
+    color: inherit;
+    text-decoration: none;
+}
+.contact-section .contact-item p a:hover {
+    color: var(--ml-primary-color);
+    text-decoration: underline;
+}
+
+.contact-section .contact-form-wrapper {
+    /* background: rgba(255,255,255,0.1); */ /* Ejemplo, config */
+    padding: 30px; /* Configurable? */
+    border-radius: var(--ml-border-radius-cards);
+    /* backdrop-filter: blur(10px); */ /* Si se quiere efecto glassmorphism */
+}
+.contact-section .form-group {
+    margin-bottom: 20px;
+}
+.contact-section .form-group input,
+.contact-section .form-group textarea {
+    width: 100%;
+    padding: 15px;
+    border: 1px solid rgba(255,255,255,0.2); /* Configurable? */
+    border-radius: var(--ml-button-border-radius); /* Usar el mismo que botones */
+    background: rgba(255,255,255,0.05); /* Configurable? */
+    color: white; /* Configurable? */
+    font-size: var(--ml-base-font-size);
+    transition: var(--ml-transition);
+    font-family: var(--ml-font-primary);
+}
+.contact-section .form-group input::placeholder,
+.contact-section .form-group textarea::placeholder {
+    color: rgba(255,255,255,0.7); /* Configurable? */
+}
+.contact-section .form-group input:focus,
+.contact-section .form-group textarea:focus {
+    outline: none;
+    border-color: var(--ml-primary-color); /* Configurable? */
+    background: rgba(255,255,255,0.1); /* Configurable? */
+}
+.contact-section .contact-form-inner .btn-primary { /* Botón de envío */
+    /* Hereda de .btn y .btn-primary */
+}
+.contact-section .contact-form-response {
+    margin-top: 15px;
+    padding: 10px;
+    border-radius: 4px;
+    font-size: 0.9em;
+}
+.contact-section .contact-form-response.success {
+    background-color: #d4edda;
+    color: #155724;
+    border: 1px solid #c3e6cb;
+}
+.contact-section .contact-form-response.error {
+    background-color: #f8d7da;
+    color: #721c24;
+    border: 1px solid #f5c6cb;
+}
+.contact-section .contact-map {
+    margin-top: 40px;
+}
+.contact-section .contact-map iframe {
+    width: 100%;
+    height: 400px; /* Configurable? */
+    border: 0;
+    border-radius: var(--ml-border-radius-cards);
+}
+
+
+/* --- Responsive Design --- */
+@media (max-width: 991px) { /* Medium devices (tablets, less than 992px) */
+    .hero-section .hero-content,
+    .banner-cta-section .banner-content,
+    .ecology-section .ecology-content,
+    .contact-section .contact-content {
+        grid-template-columns: 1fr; /* Stack elements */
+        text-align: center; /* Center text content */
+    }
+    .hero-section.layout-image_left_text_right .hero-text,
+    .banner-cta-section .banner-content.image-left .banner-text,
+    .ecology-section .ecology-content.image-left .ecology-text {
+        order: 1; /* Reset order for stacked layout */
+    }
+    .hero-section.layout-image_left_text_right .hero-image,
+    .banner-cta-section .banner-content.image-left .banner-image,
+    .ecology-section .ecology-content.image-left .ecology-image {
+        order: 2; /* Reset order */
+        margin: 30px auto 0; /* Center image below text */
+    }
+     .hero-section .hero-image,
+    .banner-cta-section .banner-image,
+    .ecology-section .ecology-image {
+        margin: 30px auto 0; /* Center image below text */
+    }
+
+    .hero-section .hero-title { font-size: calc(var(--ml-base-font-size) * var(--ml-heading-font-scale) * var(--ml-heading-font-scale) * var(--ml-heading-font-scale)); } /* H2 size */
+    .mltheme-section .section-title { font-size: calc(var(--ml-base-font-size) * var(--ml-heading-font-scale) * var(--ml-heading-font-scale)); } /* H2 size */
+
+    .services-section .services-grid.columns-3,
+    .services-section .services-grid.columns-4 {
+        grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
+    }
+    .products-section .categories-grid.columns-3,
+    .products-section .categories-grid.columns-4 {
+         grid-template-columns: repeat(auto-fit, minmax(min(100%, 300px), 1fr));
+    }
+}
+
+@media (max-width: 767px) { /* Small devices (landscape phones, less than 768px) */
+    .mltheme-section .section-header { margin-bottom: 40px; }
+    .mltheme-section .section-padding-y { --ml-section-padding-y: 40px; } /* Reduce padding */
+
+    .hero-section .hero-title { font-size: calc(var(--ml-base-font-size) * var(--ml-heading-font-scale) * var(--ml-heading-font-scale)); } /* H3 size */
+    .mltheme-section .section-title { font-size: calc(var(--ml-base-font-size) * var(--ml-heading-font-scale) * 1.5); } /* Slightly larger than H3 */
+    .mltheme-section .section-subtitle { font-size: var(--ml-base-font-size); }
+
+    .services-section .services-grid,
+    .products-section .categories-grid,
+    .products-section .products-grid {
+        grid-template-columns: 1fr; /* Stack all cards */
+    }
+
+    .brands-section .brands-track {
+        /* animation-duration: 20s; If using CSS animation */
+    }
+    .brands-section .brand-item { margin: 0 20px; height: 60px; }
+    .brands-section .brand-logo { max-height: 40px; }
+
+    .contact-section .contact-form-wrapper { padding: 20px; }
+    .btn { padding: 10px 20px; font-size: calc(var(--ml-base-font-size) * 0.9); }
+    .hero-section .hero-btn { padding: 12px 25px; font-size: var(--ml-base-font-size); }
+}
+
+/* Accessibility: Focus Visible */
+*:focus-visible {
+  outline: 3px solid var(--ml-primary-color);
+  outline-offset: 2px;
+  border-radius: 2px; /* Optional: to make the outline match element shape */
+}
+
+/* Lazyload placeholder */
+.lazyload,
+.lazyloading {
+	opacity: 0;
+}
+.lazyloaded {
+	opacity: 1;
+	transition: opacity 300ms;
+}

--- a/modules/mlthemebuilder/views/css/index.php
+++ b/modules/mlthemebuilder/views/css/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../'); // Redirect to modules/mlthemebuilder/views/
+exit;

--- a/modules/mlthemebuilder/views/img/backgrounds/index.php
+++ b/modules/mlthemebuilder/views/img/backgrounds/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../'); // Redirect to modules/mlthemebuilder/views/img/
+exit;

--- a/modules/mlthemebuilder/views/img/brands/index.php
+++ b/modules/mlthemebuilder/views/img/brands/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../'); // Redirect to modules/mlthemebuilder/views/img/
+exit;

--- a/modules/mlthemebuilder/views/img/icons/index.php
+++ b/modules/mlthemebuilder/views/img/icons/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../'); // Redirect to modules/mlthemebuilder/views/img/
+exit;

--- a/modules/mlthemebuilder/views/img/index.php
+++ b/modules/mlthemebuilder/views/img/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../'); // Redirect to modules/mlthemebuilder/views/
+exit;

--- a/modules/mlthemebuilder/views/img/placeholders/index.php
+++ b/modules/mlthemebuilder/views/img/placeholders/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../'); // Redirect to modules/mlthemebuilder/views/img/
+exit;

--- a/modules/mlthemebuilder/views/img/sections/index.php
+++ b/modules/mlthemebuilder/views/img/sections/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../'); // Redirect to modules/mlthemebuilder/views/img/
+exit;

--- a/modules/mlthemebuilder/views/index.php
+++ b/modules/mlthemebuilder/views/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../'); // Redirect to modules/mlthemebuilder/
+exit;

--- a/modules/mlthemebuilder/views/js/admin.js
+++ b/modules/mlthemebuilder/views/js/admin.js
@@ -1,0 +1,746 @@
+/**
+ * MlThemeBuilder - Admin JavaScript
+ * Handles interactions within the module's configuration page in PrestaShop Back Office.
+ */
+
+// Ensure ctb_translations is defined (should be via Media::addJsDef in controller)
+var ctb_translations = window.ctb_translations || {}; // Fallback to empty object
+
+$(document).ready(function() {
+    // Initialize jQuery UI Sortable for sections list
+    initializeSortable('#sections-list', 'UpdateSectionOrder', 'id_mltheme_section', ctb_translations.orderUpdated, ctb_translations.errorUpdatingOrder);
+    initializeSortable('#services-list', 'UpdateServiceOrder', 'id_mltheme_service', ctb_translations.orderUpdated, ctb_translations.errorUpdatingOrder);
+    initializeSortable('#brands-list', 'UpdateBrandOrder', 'id_mltheme_brand', ctb_translations.orderUpdated, ctb_translations.errorUpdatingOrder);
+
+    // --- Sections Management ---
+    // Add new section
+    $('#addNewSectionForm').on('submit', function(e) {
+        e.preventDefault();
+        const formData = $(this).serializeArray();
+        let dataToSend = {
+            ajax: true,
+            action: 'AddSection',
+            new_section_name: formData.find(item => item.name === 'new_section_name').value,
+            new_section_type: formData.find(item => item.name === 'new_section_type').value,
+            new_section_title: {}
+        };
+        formData.filter(item => item.name.startsWith('new_section_title')).forEach(item => {
+            const langId = item.name.match(/\[(\d+)\]/)[1];
+            dataToSend.new_section_title[langId] = item.value;
+        });
+
+        $.post(ctb_ajax_url, dataToSend, function(response) {
+            if (response.success && response.section) {
+                addSectionItemToDOM(response.section);
+                $('#addNewSectionForm')[0].reset();
+                showSuccessMessage(response.message || ctb_translations.itemAdded);
+            } else {
+                showErrorMessage(response.message || ctb_translations.errorSavingConfig);
+            }
+        }, 'json').fail(function() {
+            showErrorMessage(ctb_translations.errorSavingConfig + ' (AJAX Error)');
+        });
+    });
+
+    // Configure Section Button
+    $('body').on('click', '.configure-section-btn', function() {
+        const sectionId = $(this).data('id');
+        const sectionType = $(this).data('type');
+        $('#sectionModalLabel').text((ctb_translations.configureSection || 'Configure Section') ); // Default text
+        $('#section-modal-form-content').html('<p class="text-center"><i class="icon-spinner icon-spin"></i> ' + (ctb_translations.loading || 'Loading...') + '</p>');
+        $('#sectionConfigurationModal').modal('show');
+
+        $.post(ctb_ajax_url, {
+            ajax: true,
+            action: 'GetSectionForm',
+            id_mltheme_section: sectionId
+        }, function(response) {
+            if (response.success) {
+                $('#section-modal-form-content').html(response.form_html);
+                $('#sectionModalLabel').text((ctb_translations.configureSection || 'Configure Section') + ': ' + response.section_name);
+                // Initialize any JS needed for the loaded form (e.g., color pickers, RTEs)
+                if (typeof initColorPicker !== 'undefined') initColorPicker(); // If you have a global color picker init
+                if (typeof tinyMCE !== 'undefined' && typeof tinyMCE.init !== 'undefined') { // Check if TinyMCE is loaded
+                    // Example: $('textarea.rte').tinymce({...}); // Initialize RTEs if any
+                }
+                 // Initialize Bootstrap tabs if they are part of the loaded form
+                $('#section-modal-form-content .nav-tabs a').click(function (e) {
+                    e.preventDefault();
+                    $(this).tab('show');
+                });
+                // Make sure the first tab is active if it's a tabbed form
+                $('#section-modal-form-content .nav-tabs li:first-child a').tab('show');
+
+
+            } else {
+                $('#section-modal-form-content').html('<div class="alert alert-danger">' + (response.message || ctb_translations.errorLoadingForm) + '</div>');
+            }
+        }, 'json').fail(function() {
+             $('#section-modal-form-content').html('<div class="alert alert-danger">' + (ctb_translations.errorLoadingForm || 'Error loading form.') + ' (AJAX Error)</div>');
+        });
+    });
+
+    // Save Section Configuration (from Modal)
+    $('#saveSectionConfiguration').on('click', function() {
+        const form = $('#section-modal-form-content form'); // Assuming form is loaded into this div
+        if (!form.length) {
+             showErrorMessage('Configuration form not found in modal.');
+             return;
+        }
+        const formData = form.serializeArray(); // Get all form data
+        let dataToSend = {
+            ajax: true,
+            action: 'SaveSectionConfig',
+            id_mltheme_section: formData.find(item => item.name === 'id_mltheme_section')?.value || $('#section_id').val() // Fallback if id_mltheme_section is hidden input with id="section_id"
+        };
+
+        // Organize multilingual fields and config fields
+        let configFields = {};
+        let titleFields = {};
+        let contentFields = {};
+        let buttonTextFields = {};
+        let buttonLinkFields = {};
+
+        formData.forEach(item => {
+            if (item.name.startsWith('config[')) {
+                // Extract actual key: config[key][lang_id] or config[key]
+                const keyMatch = item.name.match(/^config\[([^\]]+)\](?:\[(\d+)\])?/);
+                if (keyMatch) {
+                    const mainKey = keyMatch[1];
+                    const langId = keyMatch[2];
+                    if (langId) {
+                        if (!configFields[mainKey]) configFields[mainKey] = {};
+                        configFields[mainKey][langId] = item.value;
+                    } else {
+                        configFields[mainKey] = item.value;
+                    }
+                }
+            } else if (item.name.startsWith('title[')) {
+                const langId = item.name.match(/\[(\d+)\]/)[1];
+                titleFields[langId] = item.value;
+            } else if (item.name.startsWith('content[')) {
+                const langId = item.name.match(/\[(\d+)\]/)[1];
+                contentFields[langId] = item.value;
+            } else if (item.name.startsWith('button_text[')) {
+                const langId = item.name.match(/\[(\d+)\]/)[1];
+                buttonTextFields[langId] = item.value;
+            } else if (item.name.startsWith('button_link[')) {
+                const langId = item.name.match(/\[(\d+)\]/)[1];
+                buttonLinkFields[langId] = item.value;
+            } else if (item.name !== 'id_mltheme_section') { // Avoid duplicating id if it's not in config
+                 dataToSend[item.name] = item.value; // Other direct fields
+            }
+        });
+        dataToSend.config = configFields;
+        dataToSend.title = titleFields;
+        dataToSend.content = contentFields;
+        dataToSend.button_text = buttonTextFields;
+        dataToSend.button_link = buttonLinkFields;
+
+        $.post(ctb_ajax_url, dataToSend, function(response) {
+            if (response.success) {
+                $('#sectionConfigurationModal').modal('hide');
+                showSuccessMessage(response.message || ctb_translations.configSaved);
+                // Optionally, update the section item in the list if display name changed
+                // This requires fetching the updated section name or having it in response
+            } else {
+                showErrorMessage(response.message || ctb_translations.errorSavingConfig);
+            }
+        }, 'json').fail(function() {
+            showErrorMessage(ctb_translations.errorSavingConfig + ' (AJAX Error)');
+        });
+    });
+
+    // Toggle Section Status
+    $('body').on('change', '.section-status-toggle input[type="radio"]', function() {
+        const sectionId = $(this).closest('.section-item').data('id');
+        const isActive = $(this).val() == '1';
+        $.post(ctb_ajax_url, {
+            ajax: true,
+            action: 'ToggleSectionStatus',
+            id_mltheme_section: sectionId,
+            active: isActive ? 1 : 0
+        }, function(response) {
+            if (response.success) {
+                showSuccessMessage(response.message || ctb_translations.statusUpdated);
+            } else {
+                showErrorMessage(response.message || ctb_translations.errorUpdatingStatus);
+                // Revert switch if error
+                $(this).prop('checked', !isActive);
+                $(this).siblings('input[type="radio"]').prop('checked', isActive);
+
+            }
+        }, 'json').fail(function() {
+            showErrorMessage(ctb_translations.errorUpdatingStatus + ' (AJAX Error)');
+            $(this).prop('checked', !isActive);
+            $(this).siblings('input[type="radio"]').prop('checked', isActive);
+        });
+    });
+
+    // Delete Section
+    $('body').on('click', '.delete-section-btn', function() {
+        if (!confirm(ctb_translations.confirmDeleteSection || 'Are you sure you want to delete this section?')) return;
+        const sectionItem = $(this).closest('.section-item');
+        const sectionId = sectionItem.data('id');
+        $.post(ctb_ajax_url, {
+            ajax: true,
+            action: 'DeleteSection',
+            id_mltheme_section: sectionId
+        }, function(response) {
+            if (response.success) {
+                sectionItem.fadeOut(300, function() { $(this).remove(); });
+                showSuccessMessage(response.message || ctb_translations.sectionDeleted);
+            } else {
+                showErrorMessage(response.message || ctb_translations.errorDeletingSection);
+            }
+        }, 'json').fail(function() {
+            showErrorMessage(ctb_translations.errorDeletingSection + ' (AJAX Error)');
+        });
+    });
+
+
+    // --- Services Management --- (Similar structure to Sections)
+    handleCRUDOperations({
+        listSelector: '#services-list',
+        itemSelector: '.service-item',
+        formSelector: '#serviceForm',
+        submitButtonTextSelector: '#serviceSubmitButtonText',
+        cancelButtonSelector: '#cancelEditService',
+        titleSelector: '#serviceFormTitle',
+        hiddenIdField: '#id_service',
+        deleteButtonClass: '.delete-service-btn',
+        editButtonClass: '.edit-service-btn',
+        statusToggleClass: '.service-status-toggle',
+        templateId: '#newServiceItemTemplate',
+        actions: {
+            add: 'SaveService', // SaveService handles both add and update
+            update: 'SaveService',
+            delete: 'DeleteService',
+            get: 'GetService',
+            toggleStatus: 'ToggleServiceStatus'
+        },
+        idKey: 'id_mltheme_service',
+        nameKeyForTitle: 'title_default', // Key in response object to use for title
+        nameKeyForTemplate: 'title', // Key in response object to use for template {title} placeholder
+        confirmDeleteMsg: ctb_translations.confirmDeleteService || 'Are you sure you want to delete this service?',
+        itemAddedMsg: ctb_translations.itemAdded || 'Service added.',
+        itemSavedMsg: ctb_translations.itemSaved || 'Service saved.',
+        itemDeletedMsg: ctb_translations.serviceDeleted || 'Service deleted.',
+        addTitle: ctb_translations.addServiceTitle || 'Add New Service',
+        editTitlePrefix: ctb_translations.editServiceTitlePrefix || 'Edit Service: ',
+        addButtonText: ctb_translations.addServiceBtn || 'Add Service',
+        saveButtonText: ctb_translations.saveServiceBtn || 'Save Service',
+        populateFormFunction: function(form, data) { // Custom populator for services
+            form.find('#id_service').val(data.id_mltheme_service);
+            form.find('#service_icon').val(data.icon).trigger('change'); // Trigger change for preview
+            form.find('input[name="active"][value="' + (data.active ? '1':'0') + '"]').prop('checked', true);
+
+            // Populate multilingual fields
+            for (const langId in data.title) {
+                form.find('#service_title_' + langId).val(data.title[langId]);
+            }
+            for (const langId in data.description) {
+                form.find('#service_description_' + langId).val(data.description[langId]);
+            }
+            // Show the current default language fields
+            if (typeof showServiceLangField === 'function') { // Assuming showServiceLangField exists
+                showServiceLangField(currentServiceLang || default_language);
+            }
+        },
+        getTemplateDataFunction: function(responseItem) {
+            let iconHtml = '<i class="icon-star"></i>'; // Default
+            if (responseItem.icon) {
+                if (responseItem.icon.startsWith('fa-') || responseItem.icon.startsWith('fas ') || responseItem.icon.startsWith('far ') || responseItem.icon.startsWith('fab ')) {
+                    iconHtml = '<i class="' + responseItem.icon + ' fa-lg"></i>';
+                } else {
+                    iconHtml = '<img src="' + ctb_theme_img_path + 'icons/' + responseItem.icon + '?rand='+Math.random()+'" alt="" style="max-height: 20px; max-width:20px;"/>';
+                }
+            }
+            return {
+                id: responseItem.id_mltheme_service,
+                icon_html: iconHtml,
+                title: responseItem.titles ? (responseItem.titles[default_language] || responseItem.titles[Object.keys(responseItem.titles)[0]] || 'Service') : 'Service',
+                active_on_checked: responseItem.active ? 'checked="checked"' : '',
+                active_off_checked: !responseItem.active ? 'checked="checked"' : ''
+            };
+        }
+    });
+
+    // Icon Manager Modal for Services
+    $('#openIconManager').on('click', function(e) {
+        e.preventDefault();
+        loadUploadedIcons();
+        $('#iconManagerModal').modal('show');
+    });
+
+    $('#uploadIconForm').on('submit', function(e) {
+        e.preventDefault();
+        var formData = new FormData(this);
+        formData.append('ajax', true);
+        formData.append('action', 'UploadServiceIcon'); // Or a generic 'UploadIcon' if used elsewhere
+
+        $.ajax({
+            url: ctb_ajax_url, // Make sure ctb_ajax_url is defined
+            type: 'POST',
+            data: formData,
+            contentType: false,
+            processData: false,
+            dataType: 'json',
+            success: function(response) {
+                if (response.success) {
+                    showSuccessMessage(response.message || ctb_translations.imgUploadSuccess);
+                    loadUploadedIcons(); // Refresh list
+                    // Optionally set the icon field if a context is known
+                    $('#service_icon').val(response.filename).trigger('change');
+                    $('#iconManagerModal').modal('hide');
+                } else {
+                    showErrorMessage(response.message || ctb_translations.imgUploadError);
+                }
+            },
+            error: function() {
+                showErrorMessage(ctb_translations.imgUploadError + ' (AJAX Error)');
+            }
+        });
+    });
+
+    $('body').on('click', '#uploadedIconsList .uploaded-icon-item', function() {
+        var iconFilename = $(this).data('filename');
+        $('#service_icon').val(iconFilename).trigger('change');
+        $('#iconManagerModal').modal('hide');
+    });
+
+
+    // --- Brands Management ---
+    handleCRUDOperations({
+        listSelector: '#brands-list',
+        itemSelector: '.brand-item-admin',
+        formSelector: '#brandForm',
+        submitButtonTextSelector: '#brandSubmitButtonText',
+        cancelButtonSelector: '#cancelEditBrand',
+        titleSelector: '#brandFormTitle',
+        hiddenIdField: '#id_brand',
+        deleteButtonClass: '.delete-brand-btn',
+        editButtonClass: '.edit-brand-btn',
+        statusToggleClass: '.brand-status-toggle',
+        templateId: '#newBrandItemTemplate',
+        actions: {
+            add: 'SaveBrand',
+            update: 'SaveBrand',
+            delete: 'DeleteBrand',
+            get: 'GetBrand',
+            toggleStatus: 'ToggleBrandStatus'
+        },
+        idKey: 'id_mltheme_brand',
+        nameKeyForTitle: 'name',
+        nameKeyForTemplate: 'name',
+        confirmDeleteMsg: ctb_translations.confirmDeleteBrand || 'Are you sure you want to delete this brand?',
+        itemAddedMsg: ctb_translations.itemAdded || 'Brand added.',
+        itemSavedMsg: ctb_translations.itemSaved || 'Brand saved.',
+        itemDeletedMsg: ctb_translations.brandDeleted || 'Brand deleted.',
+        addTitle: ctb_translations.addBrandTitle || 'Add New Brand',
+        editTitlePrefix: ctb_translations.editBrandTitlePrefix || 'Edit Brand: ',
+        addButtonText: ctb_translations.addBrandBtn || 'Add Brand',
+        saveButtonText: ctb_translations.saveBrandBtn || 'Save Brand',
+        populateFormFunction: function(form, data) {
+            form.find('#id_brand').val(data.id_mltheme_brand);
+            form.find('#brand_name').val(data.name);
+            form.find('#brand_url').val(data.url);
+            form.find('input[name="active"][value="' + (data.active ? '1':'0') + '"]').prop('checked', true);
+            form.find('#current_logo').val(data.logo || '');
+            if (data.logo_url) {
+                form.find('#brand_logo_preview_img').attr('src', data.logo_url + '?rand=' + Math.random()).show();
+                form.find('#brand_logo_preview_container').show();
+                form.find('#removeBrandLogoBtn').show();
+            } else {
+                form.find('#brand_logo_preview_img').hide();
+                 form.find('#brand_logo_preview_container').hide();
+                form.find('#removeBrandLogoBtn').hide();
+            }
+        },
+        getTemplateDataFunction: function(responseItem) {
+            let logoHtml = '<i class="icon-picture"></i>';
+            if (responseItem.logo_url) {
+                logoHtml = '<img src="' + responseItem.logo_url + '?rand='+Math.random()+'" alt="' + responseItem.name + '" style="max-height: 24px; max-width: 80px; border:1px solid #ddd;"/>';
+            }
+            return {
+                id: responseItem.id_mltheme_brand,
+                logo_html: logoHtml,
+                name: responseItem.name,
+                active_on_checked: responseItem.active ? 'checked="checked"' : '',
+                active_off_checked: !responseItem.active ? 'checked="checked"' : ''
+            };
+        },
+        useFormDataForSave: true // Important for file uploads
+    });
+
+    $('#brand_logo_file').on('change', function() {
+        const file = this.files[0];
+        if (file) {
+            const reader = new FileReader();
+            reader.onload = function(e) {
+                $('#brand_logo_preview_img').attr('src', e.target.result).show();
+                $('#brand_logo_preview_container').show();
+                $('#removeBrandLogoBtn').show();
+            }
+            reader.readAsDataURL(file);
+            $('#current_logo').val(''); // Clear current_logo if new file is selected
+        }
+    });
+    $('#removeBrandLogoBtn').on('click', function(){
+        $('#brand_logo_file').val(''); // Clear file input
+        $('#brand_logo_preview_img').attr('src', '#').hide();
+        $('#brand_logo_preview_container').hide();
+        $('#current_logo').val(''); // Mark for removal on server
+        $(this).hide();
+    });
+
+
+    // --- Global Settings Save (if not handled by full page reload) ---
+    // This is typically handled by PrestaShop's HelperOptions or a standard form submission
+    // If you have a specific "Save Global Settings" button that should use AJAX:
+    $('#module_form_submit_btn').on('click', function(e) {
+        if ($(this).attr('name') === 'submitCustomThemeBuilderGlobal') { // Check if it's the global save
+            // e.preventDefault(); // Uncomment if you want to handle via AJAX
+            // var formData = $('#module_form').serialize(); // Or specific parts
+            // $.post(ctb_ajax_url, formData + '&action=SaveGlobalSettings&ajax=1', function(response) { ... });
+        }
+    });
+
+
+    // --- Image Uploader for Section Configs (Modal) ---
+    $('body').on('click', '.btn-file-uploader', function() {
+        var $button = $(this);
+        var inputId = $button.data('input-id');
+        var previewId = $button.data('preview-id');
+        var uploadType = $button.data('upload-type'); // e.g. 'section_image', 'section_background'
+        var sectionId = $button.data('section-id'); // Current section ID
+
+        var $fileInput = $('<input type="file" accept="image/*" style="display:none;">');
+        $('body').append($fileInput);
+
+        $fileInput.on('change', function() {
+            var file = this.files[0];
+            if (file) {
+                var formData = new FormData();
+                formData.append('file', file);
+                formData.append('ajax', true);
+                formData.append('action', 'UploadImage'); // Generic AJAX action for image uploads
+                formData.append('upload_type', uploadType);
+                formData.append('id_item', sectionId); // Pass relevant ID
+
+                // Show a loading indicator if you have one
+                // $button.find('i').removeClass('icon-upload').addClass('icon-spinner icon-spin');
+
+                $.ajax({
+                    url: ctb_ajax_url,
+                    type: 'POST',
+                    data: formData,
+                    contentType: false,
+                    processData: false,
+                    dataType: 'json',
+                    success: function(response) {
+                        if (response.success) {
+                            $('#' + inputId).val(response.filename);
+                            if (previewId && $('#' + previewId).length) {
+                                $('#' + previewId).attr('src', response.url + '?rand=' + Math.random()).show();
+                                // Show remove button for the preview
+                                 $('#' + previewId).next('.remove-image-btn').show();
+                            }
+                            showSuccessMessage(response.message || ctb_translations.imgUploadSuccess);
+                        } else {
+                            showErrorMessage(response.message || ctb_translations.imgUploadError);
+                        }
+                    },
+                    error: function() {
+                        showErrorMessage(ctb_translations.imgUploadError + ' (AJAX Error)');
+                    },
+                    complete: function() {
+                        // $button.find('i').removeClass('icon-spinner icon-spin').addClass('icon-upload');
+                        $fileInput.remove(); // Clean up temporary file input
+                    }
+                });
+            } else {
+                $fileInput.remove();
+            }
+        });
+        $fileInput.click(); // Trigger file selection
+    });
+
+    // Remove image button for section config images
+    $('body').on('click', '.remove-image-btn', function() {
+        var inputId = $(this).data('input-id');
+        var previewId = $(this).data('preview-id');
+        $('#' + inputId).val('');
+        if (previewId && $('#' + previewId).length) {
+            $('#' + previewId).attr('src', '#').hide();
+        }
+        $(this).hide();
+    });
+
+
+    // Initialize tooltips (if Bootstrap tooltips are used)
+    if (typeof $('[data-toggle="tooltip"]').tooltip === 'function') {
+        $('[data-toggle="tooltip"]').tooltip();
+    }
+
+}); // End document.ready
+
+// --- Helper Functions ---
+function initializeSortable(listSelector, ajaxAction, idKey, successMsg, errorMsg) {
+    $(listSelector).sortable({
+        handle: '.drag-handle',
+        placeholder: 'ui-sortable-placeholder',
+        update: function(event, ui) {
+            var order = $(this).sortable('toArray', { attribute: 'data-id' });
+            var orderData = order.map(id => ({ id: id })); // Simplified for some cases, might need full {id: position} map
+
+            $.post(ctb_ajax_url, {
+                ajax: true,
+                action: ajaxAction,
+                order: orderData, // Send array of IDs in new order
+                [idKey]: order // Some actions might expect the list of IDs directly
+            }, function(response) {
+                if (response.success) {
+                    showSuccessMessage(response.message || successMsg);
+                    // Update position numbers in DOM if displayed
+                    $(listSelector).find('.section-item, .service-item, .brand-item-admin').each(function(index) {
+                        $(this).find('.section-position, .service-position, .brand-position').text(index + 1);
+                    });
+                } else {
+                    showErrorMessage(response.message || errorMsg);
+                    $(listSelector).sortable('cancel'); // Revert if error
+                }
+            }, 'json').fail(function() {
+                showErrorMessage(errorMsg + ' (AJAX Error)');
+                $(listSelector).sortable('cancel');
+            });
+        }
+    });
+}
+
+function addSectionItemToDOM(section) {
+    var template = $('#newSectionTemplate').html();
+    template = template.replace(/{id}/g, section.id_mltheme_section)
+                       .replace(/{type}/g, section.type)
+                       .replace(/{name}/g, section.display_name) // Use display_name for visible name
+                       .replace(/{raw_name}/g, section.name)     // Use raw_name for internal name display
+                       .replace(/{position}/g, section.position);
+    $('#sections-list').append(template);
+    // Re-initialize Bootstrap switches if they are not auto-initialized
+    // if (typeof $.fn.bootstrapSwitch !== 'undefined') {
+    //     $('#sections-list .section-item[data-id="'+section.id_mltheme_section+'"] .prestashop-switch').bootstrapSwitch();
+    // }
+}
+
+function loadUploadedIcons() {
+    var listDiv = $('#uploadedIconsList');
+    listDiv.html('<p class="text-center"><i class="icon-spinner icon-spin"></i> ' + (ctb_translations.loading || 'Loading...') + '</p>');
+    $.post(ctb_ajax_url, { ajax: true, action: 'GetUploadedIcons' }, function(response) {
+        if (response.success && response.icons && response.icons.length > 0) {
+            listDiv.empty();
+            response.icons.forEach(function(icon) {
+                listDiv.append(
+                    '<div class="col-xs-4 col-sm-3 col-md-2">' +
+                        '<div class="uploaded-icon-item" data-filename="' + icon.name + '">' +
+                            '<img src="' + icon.url + '?rand='+Math.random()+'" alt="' + icon.name + '">' +
+                            '<span>' + icon.name + '</span>' +
+                        '</div>' +
+                    '</div>'
+                );
+            });
+        } else if (response.success) {
+             listDiv.html('<p class="text-muted col-xs-12">' + (ctb_translations.noIconsUploaded || 'No icons uploaded yet.') + '</p>');
+        } else {
+            listDiv.html('<p class="alert alert-warning col-xs-12">' + (response.message || ctb_translations.errorLoadingIcons || 'Error loading icons.') + '</p>');
+        }
+    }, 'json').fail(function(){
+        listDiv.html('<p class="alert alert-danger col-xs-12">' + (ctb_translations.errorLoadingIconsAjax || 'AJAX Error loading icons.') + '</p>');
+    });
+}
+
+
+// Generic CRUD handler
+function handleCRUDOperations(options) {
+    const {
+        listSelector, itemSelector, formSelector, submitButtonTextSelector, cancelButtonSelector, titleSelector,
+        hiddenIdField, deleteButtonClass, editButtonClass, statusToggleClass, templateId,
+        actions, idKey, nameKeyForTitle, nameKeyForTemplate,
+        confirmDeleteMsg, itemAddedMsg, itemSavedMsg, itemDeletedMsg,
+        addTitle, editTitlePrefix, addButtonText, saveButtonText,
+        populateFormFunction, getTemplateDataFunction, useFormDataForSave = false
+    } = options;
+
+    // Add/Update
+    $(formSelector).on('submit', function(e) {
+        e.preventDefault();
+        const isUpdate = parseInt($(hiddenIdField).val()) > 0;
+        const action = isUpdate ? actions.update : actions.add;
+
+        let saveData;
+        let ajaxOptions = {
+            url: ctb_ajax_url,
+            type: 'POST',
+            dataType: 'json',
+            success: function(response) {
+                if (response.success) {
+                    showSuccessMessage(response.message || (isUpdate ? itemSavedMsg : itemAddedMsg));
+                    if (!isUpdate && response[idKey.replace('id_','')]) { // Check if response has the item data
+                         const templateData = getTemplateDataFunction(response[idKey.replace('id_','')]);
+                         addGenericItemToDOM(templateId, listSelector, templateData);
+                    } else if (isUpdate) {
+                        // Update existing item in DOM if needed (e.g., name changed)
+                        const itemInList = $(listSelector).find(itemSelector + '[data-id="' + $(hiddenIdField).val() + '"]');
+                        if (itemInList.length && response[idKey.replace('id_','')]) {
+                            const templateData = getTemplateDataFunction(response[idKey.replace('id_','')]);
+                            // Simplistic update: replace name and icon/logo
+                            itemInList.find('.section-name').text(templateData[nameKeyForTemplate]); // Assuming .section-name is used
+                            if (templateData.icon_html) itemInList.find('.service-icon-preview').html(templateData.icon_html);
+                            if (templateData.logo_html) itemInList.find('.brand-logo-preview').html(templateData.logo_html);
+                        }
+                    }
+                    resetGenericForm(formSelector, titleSelector, addTitle, submitButtonTextSelector, addButtonText, cancelButtonSelector, hiddenIdField);
+                } else {
+                    showErrorMessage(response.message || ctb_translations.errorSavingConfig);
+                }
+            },
+            error: function() {
+                showErrorMessage(ctb_translations.errorSavingConfig + ' (AJAX Error)');
+            }
+        };
+
+        if (useFormDataForSave) {
+            saveData = new FormData(this);
+            saveData.append('ajax', true);
+            saveData.append('action', action);
+            ajaxOptions.data = saveData;
+            ajaxOptions.contentType = false;
+            ajaxOptions.processData = false;
+        } else {
+            saveData = $(this).serialize() + '&ajax=true&action=' + action;
+            ajaxOptions.data = saveData;
+        }
+
+        $.ajax(ajaxOptions);
+    });
+
+    // Edit
+    $('body').on('click', editButtonClass, function() {
+        const itemId = $(this).data('id');
+        $.post(ctb_ajax_url, { ajax: true, action: actions.get, [idKey]: itemId }, function(response) {
+            if (response.success && response[idKey.replace('id_','')]) {
+                const itemData = response[idKey.replace('id_','')];
+                populateFormFunction($(formSelector), itemData);
+                $(titleSelector).text(editTitlePrefix + (itemData[nameKeyForTitle] || itemId));
+                $(submitButtonTextSelector).text(saveButtonText);
+                $(cancelButtonSelector).show();
+                $(formSelector).find('input[type="file"]').val(''); // Clear file input on edit
+            } else {
+                showErrorMessage(response.message || 'Error fetching item data.');
+            }
+        }, 'json').fail(function() {
+            showErrorMessage('Error fetching item data (AJAX Error).');
+        });
+    });
+
+    // Delete
+    $('body').on('click', deleteButtonClass, function() {
+        if (!confirm(confirmDeleteMsg)) return;
+        const itemElement = $(this).closest(itemSelector);
+        const itemId = itemElement.data('id');
+        $.post(ctb_ajax_url, { ajax: true, action: actions.delete, [idKey]: itemId }, function(response) {
+            if (response.success) {
+                itemElement.fadeOut(300, function() { $(this).remove(); });
+                showSuccessMessage(response.message || itemDeletedMsg);
+            } else {
+                showErrorMessage(response.message || 'Error deleting item.');
+            }
+        }, 'json').fail(function() {
+            showErrorMessage('Error deleting item (AJAX Error).');
+        });
+    });
+
+    // Toggle Status
+    $('body').on('change', statusToggleClass + ' input[type="radio"]', function() {
+        const itemId = $(this).closest(itemSelector).data('id');
+        const isActive = $(this).val() == '1';
+        $.post(ctb_ajax_url, {
+            ajax: true,
+            action: actions.toggleStatus,
+            [idKey]: itemId,
+            active: isActive ? 1 : 0
+        }, function(response) {
+            if (response.success) {
+                showSuccessMessage(response.message || ctb_translations.statusUpdated);
+            } else {
+                showErrorMessage(response.message || ctb_translations.errorUpdatingStatus);
+                // Revert switch
+                $(this).prop('checked', !isActive).siblings('input[type="radio"]').prop('checked', isActive);
+            }
+        }, 'json').fail(function() {
+             showErrorMessage(ctb_translations.errorUpdatingStatus + ' (AJAX Error)');
+             $(this).prop('checked', !isActive).siblings('input[type="radio"]').prop('checked', isActive);
+        });
+    });
+
+    // Cancel Edit
+    $(cancelButtonSelector).on('click', function() {
+        resetGenericForm(formSelector, titleSelector, addTitle, submitButtonTextSelector, addButtonText, cancelButtonSelector, hiddenIdField);
+         $(formSelector).find('input[type="file"]').val(''); // Clear file input
+         // Clear previews for images if any
+         $(formSelector).find('#brand_logo_preview_img, #service_icon_preview_img').hide().attr('src','#'); // Example
+         $(formSelector).find('#current_logo, #current_icon').val('');
+    });
+}
+
+function resetGenericForm(formSelector, titleSelector, addTitle, submitTextSelector, addBtnText, cancelBtnSelector, idFieldSelector) {
+    $(formSelector)[0].reset();
+    $(titleSelector).text(addTitle);
+    $(submitTextSelector).text(addBtnText);
+    $(cancelBtnSelector).hide();
+    $(idFieldSelector).val('0');
+    // Reset any specific previews or states
+    if (formSelector === '#brandForm') {
+        $('#brand_logo_preview_img').attr('src', '#').hide();
+        $('#brand_logo_preview_container').hide();
+        $('#removeBrandLogoBtn').hide();
+        $('#current_logo').val('');
+    }
+    // Reset language fields to default if applicable (e.g., for services)
+    if (typeof showServiceLangField === 'function') { showServiceLangField(default_language); }
+
+}
+
+function addGenericItemToDOM(templateId, listSelector, data) {
+    var template = $(templateId).html();
+    for (var key in data) {
+        if (data.hasOwnProperty(key)) {
+            var regex = new RegExp('{' + key + '}', 'g');
+            template = template.replace(regex, data[key]);
+        }
+    }
+    $(listSelector).append(template);
+}
+
+
+// PrestaShop specific growl-like notifications (if available, otherwise use alert)
+function showSuccessMessage(message) {
+    if (typeof showSuccessMessage === 'function' && $.fn.growl) { // Check if PS's showSuccessMessage is available
+         $.growl.notice({ title: '', message: message }); // PS 1.7 growl
+    } else if (typeof displayConfirmation === 'function') {
+        displayConfirmation(message); // PS 1.6
+    }
+     else {
+        alert('Success: ' + message);
+    }
+}
+
+function showErrorMessage(message) {
+     if (typeof showErrorMessage === 'function' && $.fn.growl) { // Check if PS's showErrorMessage is available
+        $.growl.error({ title: '', message: message }); // PS 1.7 growl
+    } else if (typeof displayError === 'function') {
+        displayError(message); // PS 1.6
+    }
+     else {
+        alert('Error: ' + message);
+    }
+}

--- a/modules/mlthemebuilder/views/js/front.js
+++ b/modules/mlthemebuilder/views/js/front.js
@@ -1,0 +1,413 @@
+/**
+ * MlThemeBuilder - Frontend JavaScript
+ * Handles theme interactions, animations, and dynamic behaviors.
+ */
+
+(function() {
+    'use strict';
+
+    const MlTheme = {
+        // Configuration (can be overridden by data attributes or global JS vars if needed)
+        config: {
+            animationOffset: '100px', // How far from bottom of viewport to trigger animation
+            lazyLoadOffset: '200px',  // How far from bottom of viewport to start loading images
+            throttleDelay: 100,       // Milliseconds for scroll/resize throttle
+            debounceDelay: 250,       // Milliseconds for resize debounce
+            smoothScrollDuration: 800,
+            brandsSlider: {
+                speed: '30s', // Default animation speed for brands slider (CSS animation duration)
+                pauseOnHover: true
+            },
+            contactForm: {
+                ajaxUrl: (typeof prestashop !== 'undefined' && prestashop.urls.base_url ? prestashop.urls.base_url + 'modules/mlthemebuilder/ajax.php' : './modules/mlthemebuilder/ajax.php'), // Fallback, should be set via Media::addJsDef
+                clearFormAfterSuccess: true
+            }
+        },
+
+        // Initialization
+        init: function() {
+            this.setGlobalAjaxUrl(); // Set AJAX URL from prestashop object if available
+            this.initSmoothScroll();
+            this.initScrollAnimations();
+            this.initLazyLoading();
+            this.initMobileMenu();
+            this.initStickyHeader();
+            this.initScrollToTop();
+            this.initRippleEffects();
+            this.initBrandsSlider();
+            this.initContactForms();
+            // Add other initializations here (e.g., carousels, parallax, etc.)
+
+            // Event listeners with throttling/debouncing
+            window.addEventListener('scroll', this.utils.throttle(this.onScroll.bind(this), this.config.throttleDelay));
+            window.addEventListener('resize', this.utils.debounce(this.onResize.bind(this), this.config.debounceDelay));
+
+            // Initial check for elements in viewport (e.g., for animations on page load)
+            this.onScroll();
+            this.onResize();
+            console.log('MlThemeBuilder Frontend JS Initialized.');
+        },
+
+        setGlobalAjaxUrl: function() {
+            if (typeof prestashop !== 'undefined' && prestashop.urls && prestashop.urls.base_url) {
+                // A more robust way to get the AJAX URL would be via a dedicated controller link
+                // For now, assuming a generic ajax.php or using the contact form one as a base.
+                // This should ideally be set via Media::addJsDef in the module's PHP.
+                // Example: prestashop.modules.mlthemebuilder.ajaxUrl
+                if (prestashop.modules && prestashop.modules.mlthemebuilder && prestashop.modules.mlthemebuilder.ajaxUrl) {
+                     this.config.contactForm.ajaxUrl = prestashop.modules.mlthemebuilder.ajaxUrl;
+                } else {
+                    // Fallback if not defined specifically
+                    // This is a guess, actual AJAX endpoint might be different or part of a controller
+                    // For contact form, it might be a specific action to the module's controller.
+                    // The user's ajax-handler.php was in /ajax/ directory, not a controller.
+                    // So, this path needs to be correct.
+                    this.config.contactForm.ajaxUrl = prestashop.urls.base_url + 'modules/mlthemebuilder/ajax-mlthemebuilder.php';
+                }
+            }
+        },
+
+        // --- Event Handlers (Throttled/Debounced) ---
+        onScroll: function() {
+            this.checkScrollAnimations();
+            this.checkLazyLoad();
+            this.checkStickyHeader();
+            this.checkScrollToTopButton();
+        },
+
+        onResize: function() {
+            // Recalculate layouts or element positions if needed
+            this.closeMobileMenuOnDesktop(); // Example
+        },
+
+        // --- Smooth Scrolling for Anchors ---
+        initSmoothScroll: function() {
+            document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+                anchor.addEventListener('click', function (e) {
+                    const href = this.getAttribute('href');
+                    if (href === '#' || href === '#!') return; // Ignore empty or placeholder links
+
+                    const targetElement = document.querySelector(href);
+                    if (targetElement) {
+                        e.preventDefault();
+                        const offsetTop = targetElement.getBoundingClientRect().top + window.pageYOffset;
+                        // Consider fixed header height if any
+                        const headerHeight = document.querySelector('header.sticky') ? document.querySelector('header.sticky').offsetHeight : 0;
+
+                        window.scrollTo({
+                            top: offsetTop - headerHeight - 20, // Extra 20px offset
+                            behavior: 'smooth'
+                        });
+                    }
+                });
+            });
+        },
+
+        // --- Scroll Animations ---
+        initScrollAnimations: function() {
+            this.animatedElements = document.querySelectorAll('.ml-animate-on-scroll');
+            if (!this.animatedElements.length) return;
+            // Initial check in case elements are already in view
+            this.checkScrollAnimations();
+        },
+        checkScrollAnimations: function() {
+            if (!this.animatedElements || !this.animatedElements.length) return;
+            this.animatedElements.forEach(el => {
+                if (this.utils.isElementInView(el, this.config.animationOffset) && !el.classList.contains('is-visible')) {
+                    el.classList.add('is-visible');
+                    // Optional: remove event listener or class after animation to save resources
+                    // if (el.dataset.animOnce) {
+                    //    el.classList.remove('ml-animate-on-scroll');
+                    // }
+                }
+            });
+        },
+
+        // --- Lazy Loading ---
+        initLazyLoading: function() {
+            this.lazyLoadImages = document.querySelectorAll('img.lazyload');
+            if (!this.lazyLoadImages.length) return;
+
+            // Support for IntersectionObserver if available
+            if ('IntersectionObserver' in window) {
+                const observer = new IntersectionObserver((entries, obs) => {
+                    entries.forEach(entry => {
+                        if (entry.isIntersecting) {
+                            this.loadLazyImage(entry.target);
+                            obs.unobserve(entry.target);
+                        }
+                    });
+                }, { rootMargin: this.config.lazyLoadOffset });
+                this.lazyLoadImages.forEach(img => observer.observe(img));
+            } else {
+                // Fallback for older browsers (less performant)
+                this.checkLazyLoad(); // Initial check
+                // Scroll/resize events will call checkLazyLoad via onScroll
+            }
+        },
+        loadLazyImage: function(img) {
+            if (img.dataset.src) {
+                img.src = img.dataset.src;
+                if (img.dataset.srcset) {
+                    img.srcset = img.dataset.srcset;
+                }
+                img.classList.remove('lazyload');
+                img.classList.add('lazyloaded');
+                img.removeAttribute('data-src');
+                img.removeAttribute('data-srcset');
+            }
+        },
+        checkLazyLoad: function() { // Fallback if IntersectionObserver not supported
+            if ('IntersectionObserver' in window || !this.lazyLoadImages || !this.lazyLoadImages.length) return;
+
+            this.lazyLoadImages.forEach(img => {
+                if (img.classList.contains('lazyload') && this.utils.isElementInView(img, this.config.lazyLoadOffset)) {
+                    this.loadLazyImage(img);
+                }
+            });
+            // Remove loaded images from the list to improve performance
+            this.lazyLoadImages = Array.from(this.lazyLoadImages).filter(img => img.classList.contains('lazyload'));
+        },
+
+        // --- Mobile Menu ---
+        initMobileMenu: function() {
+            const menuToggle = document.querySelector('.ml-menu-toggle'); // Standardize class name
+            const mobileNav = document.querySelector('.ml-mobile-nav'); // Standardize class name
+
+            if (menuToggle && mobileNav) {
+                menuToggle.addEventListener('click', () => {
+                    menuToggle.classList.toggle('active');
+                    mobileNav.classList.toggle('active');
+                    document.body.classList.toggle('mobile-menu-active'); // For potential overflow hidden
+                });
+
+                // Close menu when a link is clicked (for single-page navigation)
+                mobileNav.querySelectorAll('a').forEach(link => {
+                    link.addEventListener('click', () => {
+                        if (mobileNav.classList.contains('active')) {
+                             menuToggle.classList.remove('active');
+                             mobileNav.classList.remove('active');
+                             document.body.classList.remove('mobile-menu-active');
+                        }
+                    });
+                });
+            }
+        },
+        closeMobileMenuOnDesktop: function() {
+            if (window.innerWidth > 991) { // Assuming 992px is desktop breakpoint
+                const menuToggle = document.querySelector('.ml-menu-toggle.active');
+                const mobileNav = document.querySelector('.ml-mobile-nav.active');
+                if (menuToggle && mobileNav) {
+                    menuToggle.classList.remove('active');
+                    mobileNav.classList.remove('active');
+                    document.body.classList.remove('mobile-menu-active');
+                }
+            }
+        },
+
+        // --- Sticky Header ---
+        initStickyHeader: function() {
+            this.header = document.querySelector('header.ml-main-header'); // Standardize class name
+            this.stickyOffset = this.header ? (parseInt(this.header.dataset.stickyOffset) || 100) : 100;
+            if (!this.header) return;
+            this.checkStickyHeader(); // Initial check
+        },
+        checkStickyHeader: function() {
+            if (!this.header) return;
+            if (window.pageYOffset > this.stickyOffset) {
+                this.header.classList.add('sticky');
+            } else {
+                this.header.classList.remove('sticky');
+            }
+        },
+
+        // --- Scroll to Top Button ---
+        initScrollToTop: function() {
+            this.scrollToTopButton = document.querySelector('.ml-scroll-to-top'); // Standardize
+            if (!this.scrollToTopButton) return;
+
+            this.scrollToTopButton.addEventListener('click', (e) => {
+                e.preventDefault();
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+            });
+            this.checkScrollToTopButton(); // Initial check
+        },
+        checkScrollToTopButton: function() {
+            if (!this.scrollToTopButton) return;
+            if (window.pageYOffset > 300) { // Show after 300px scroll
+                this.scrollToTopButton.classList.add('visible');
+            } else {
+                this.scrollToTopButton.classList.remove('visible');
+            }
+        },
+
+        // --- Ripple Effect for Buttons ---
+        initRippleEffects: function() {
+            document.querySelectorAll('.btn.ml-ripple-effect').forEach(button => { // Standardize
+                button.addEventListener('click', function(e) {
+                    const existingRipple = this.querySelector(".ripple");
+                    if (existingRipple) existingRipple.remove();
+
+                    const circle = document.createElement("span");
+                    const diameter = Math.max(this.clientWidth, this.clientHeight);
+                    const radius = diameter / 2;
+
+                    circle.style.width = circle.style.height = `${diameter}px`;
+                    // Get click position relative to the button
+                    const rect = this.getBoundingClientRect();
+                    circle.style.left = `${e.clientX - rect.left - radius}px`;
+                    circle.style.top = `${e.clientY - rect.top - radius}px`;
+                    circle.classList.add("ripple");
+
+                    this.appendChild(circle);
+                });
+            });
+        },
+
+        // --- Brands Slider ---
+        initBrandsSlider: function() {
+            const sliders = document.querySelectorAll('.brands-section .brands-slider');
+            sliders.forEach(slider => {
+                const track = slider.querySelector('.brands-track');
+                if (!track) return;
+
+                const items = track.querySelectorAll('.brand-item');
+                if (items.length === 0) return;
+
+                // Clone items for infinite effect
+                items.forEach(item => track.appendChild(item.cloneNode(true)));
+
+                // Set animation duration from data attribute or config
+                const duration = slider.dataset.duration || this.config.brandsSlider.speed;
+                track.style.animationDuration = duration;
+                track.classList.add('css-animated'); // Add class to trigger CSS animation
+
+                if (this.config.brandsSlider.pauseOnHover) {
+                    slider.addEventListener('mouseenter', () => track.style.animationPlayState = 'paused');
+                    slider.addEventListener('mouseleave', () => track.style.animationPlayState = 'running');
+                }
+            });
+        },
+
+        // --- Contact Forms ---
+        initContactForms: function() {
+            const forms = document.querySelectorAll('form.contact-form-inner'); // Class from contact.tpl
+            forms.forEach(form => {
+                form.addEventListener('submit', this.handleContactFormSubmit.bind(this));
+            });
+        },
+        handleContactFormSubmit: function(e) {
+            e.preventDefault();
+            const form = e.target;
+            const submitButton = form.querySelector('button[type="submit"]');
+            const responseDiv = form.querySelector('.contact-form-response');
+
+            if (!responseDiv) {
+                console.error('Contact form response div not found.');
+                return;
+            }
+
+            // Basic validation (can be enhanced)
+            let isValid = true;
+            form.querySelectorAll('[required]').forEach(input => {
+                if (!input.value.trim()) {
+                    isValid = false;
+                    input.classList.add('error'); // Add error class for styling
+                } else {
+                    input.classList.remove('error');
+                }
+            });
+
+            if (!isValid) {
+                responseDiv.innerHTML = `<p class="error">${prestashop.modules.mlthemebuilder.translations.fillRequiredFields || 'Please fill all required fields.'}</p>`;
+                responseDiv.style.display = 'block';
+                responseDiv.className = 'contact-form-response error';
+                return;
+            }
+
+            const formData = new FormData(form);
+            formData.append('action', 'submitContactForm'); // AJAX action for your handler
+            formData.append('ajax', '1');
+            // Add security token if your AJAX handler requires it
+            // formData.append('token', prestashop.static_token);
+
+            const originalButtonText = submitButton.innerHTML;
+            submitButton.innerHTML = prestashop.modules.mlthemebuilder.translations.sending || 'Sending...';
+            submitButton.disabled = true;
+            responseDiv.style.display = 'none';
+
+            fetch(this.config.contactForm.ajaxUrl, {
+                method: 'POST',
+                body: formData
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    responseDiv.innerHTML = `<p class="success">${data.message || prestashop.modules.mlthemebuilder.translations.messageSent || 'Message sent successfully!'}</p>`;
+                    responseDiv.className = 'contact-form-response success';
+                    if (this.config.contactForm.clearFormAfterSuccess) {
+                        form.reset();
+                    }
+                } else {
+                    responseDiv.innerHTML = `<p class="error">${data.message || prestashop.modules.mlthemebuilder.translations.errorSendingMessage || 'An error occurred. Please try again.'}</p>`;
+                     responseDiv.className = 'contact-form-response error';
+                }
+            })
+            .catch(error => {
+                console.error('Contact form submission error:', error);
+                responseDiv.innerHTML = `<p class="error">${prestashop.modules.mlthemebuilder.translations.errorSendingMessage || 'An error occurred. Please try again.'}</p>`;
+                responseDiv.className = 'contact-form-response error';
+            })
+            .finally(() => {
+                submitButton.innerHTML = originalButtonText;
+                submitButton.disabled = false;
+                responseDiv.style.display = 'block';
+                setTimeout(() => { responseDiv.style.display = 'none'; }, 5000); // Hide after 5s
+            });
+        },
+
+
+        // --- Utility Functions ---
+        utils: {
+            isElementInView: function(el, offset = '0px') {
+                const rect = el.getBoundingClientRect();
+                const viewHeight = Math.max(document.documentElement.clientHeight, window.innerHeight);
+                // Check if bottom of element is past the top of viewport (minus offset)
+                // AND top of element is before the bottom of viewport (plus offset)
+                return !(rect.bottom < 0 || rect.top - viewHeight >= parseInt(offset));
+            },
+            throttle: function(func, limit) {
+                let inThrottle;
+                return function() {
+                    const args = arguments;
+                    const context = this;
+                    if (!inThrottle) {
+                        func.apply(context, args);
+                        inThrottle = true;
+                        setTimeout(() => inThrottle = false, limit);
+                    }
+                };
+            },
+            debounce: function(func, delay) {
+                let timeout;
+                return function() {
+                    const context = this;
+                    const args = arguments;
+                    clearTimeout(timeout);
+                    timeout = setTimeout(() => func.apply(context, args), delay);
+                };
+            }
+        }
+    };
+
+    // Initialize the theme scripts when DOM is ready
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => MlTheme.init());
+    } else {
+        MlTheme.init(); // DOMContentLoaded has already fired
+    }
+
+    // Expose MlTheme to global scope if needed for debugging or external calls
+    window.MlTheme = MlTheme;
+
+})();

--- a/modules/mlthemebuilder/views/js/index.php
+++ b/modules/mlthemebuilder/views/js/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../'); // Redirect to modules/mlthemebuilder/views/
+exit;

--- a/modules/mlthemebuilder/views/js/mlthemebuilder.js
+++ b/modules/mlthemebuilder/views/js/mlthemebuilder.js
@@ -1,0 +1,21 @@
+/**
+ * MlThemeBuilder - Main Theme Builder JS (if needed for specific admin interactions not covered by admin.js)
+ * This file could be used for more complex UI interactions within the Theme Builder configuration page
+ * that are specific to the overall "builder" experience, rather than generic CRUD for items.
+ *
+ * For now, most of the logic is in admin.js. This file is a placeholder or for future expansion.
+ */
+
+$(document).ready(function() {
+    console.log('MlThemeBuilder main JS file loaded (mlthemebuilder.js)');
+
+    // Example: Initialize a more complex UI component if one existed
+    // if (typeof MyThemeBuilderUIComponent !== 'undefined') {
+    //     MyThemeBuilderUIComponent.init();
+    // }
+
+    // Example: Event delegation for dynamically added elements if not covered by admin.js handlers
+    // $('#mlthemebuilder-config').on('click', '.some-dynamic-button', function() {
+    //     // ... handle click ...
+    // });
+});

--- a/modules/mlthemebuilder/views/templates/admin/helpers/form.tpl
+++ b/modules/mlthemebuilder/views/templates/admin/helpers/form.tpl
@@ -1,0 +1,101 @@
+{* This is a generic helper form template. It might not be directly used if using PrestaShop's HelperForm class,
+   as HelperForm generates its own markup. However, if building forms manually or for very custom parts of the admin,
+   this structure could be a starting point. The modal forms for sections (hero.tpl, etc.) are more specific.
+
+   For most admin forms, you'd use $helper->generateForm($fields_form).
+   This file is more for demonstrating structure if you were to build a form manually with Smarty.
+*}
+
+{if isset($custom_form_fields) && $custom_form_fields}
+    <form action="{$form_action|escape:'htmlall':'UTF-8'}" method="post" class="defaultForm form-horizontal" enctype="multipart/form-data">
+        <div class="panel">
+            <div class="panel-heading">
+                <i class="icon-{$form_icon|default:'cog'|escape:'htmlall':'UTF-8'}"></i> {$form_title|default:'Form'|escape:'htmlall':'UTF-8'}
+            </div>
+            <div class="panel-body">
+                {foreach from=$custom_form_fields item=field}
+                    <div class="form-group">
+                        <label class="control-label col-lg-3" for="{$field.name|escape:'htmlall':'UTF-8'}">
+                            {$field.label|escape:'htmlall':'UTF-8'}
+                            {if isset($field.required) && $field.required}<span class="text-danger">*</span>{/if}
+                        </label>
+                        <div class="col-lg-9">
+                            {if $field.type == 'text' || $field.type == 'password' || $field.type == 'email' || $field.type == 'number' || $field.type == 'color'}
+                                <input type="{$field.type|escape:'htmlall':'UTF-8'}"
+                                       name="{$field.name|escape:'htmlall':'UTF-8'}"
+                                       id="{$field.name|escape:'htmlall':'UTF-8'}"
+                                       value="{$field.value|default:''|escape:'htmlall':'UTF-8'}"
+                                       class="form-control {if isset($field.class)}{$field.class|escape:'htmlall':'UTF-8'}{/if}"
+                                       {if isset($field.placeholder)}placeholder="{$field.placeholder|escape:'htmlall':'UTF-8'}"{/if}
+                                       {if isset($field.required) && $field.required}required{/if}
+                                       {if isset($field.min)}min="{$field.min|escape:'htmlall':'UTF-8'}"{/if}
+                                       {if isset($field.max)}max="{$field.max|escape:'htmlall':'UTF-8'}"{/if}
+                                       {if isset($field.step)}step="{$field.step|escape:'htmlall':'UTF-8'}"{/if}>
+                            {elseif $field.type == 'textarea'}
+                                <textarea name="{$field.name|escape:'htmlall':'UTF-8'}"
+                                          id="{$field.name|escape:'htmlall':'UTF-8'}"
+                                          class="form-control {if isset($field.class)}{$field.class|escape:'htmlall':'UTF-8'}{/if}"
+                                          rows="{$field.rows|default:5|escape:'htmlall':'UTF-8'}"
+                                          {if isset($field.placeholder)}placeholder="{$field.placeholder|escape:'htmlall':'UTF-8'}"{/if}
+                                          {if isset($field.required) && $field.required}required{/if}
+                                >{$field.value|default:''|escape:'htmlall':'UTF-8'}</textarea>
+                            {elseif $field.type == 'select'}
+                                <select name="{$field.name|escape:'htmlall':'UTF-8'}"
+                                        id="{$field.name|escape:'htmlall':'UTF-8'}"
+                                        class="form-control {if isset($field.class)}{$field.class|escape:'htmlall':'UTF-8'}{/if}"
+                                        {if isset($field.required) && $field.required}required{/if}>
+                                    {if isset($field.options) && is_array($field.options)}
+                                        {foreach from=$field.options item=option}
+                                            <option value="{$option.value|escape:'htmlall':'UTF-8'}" {if $option.value == $field.value|default:''}selected{/if}>
+                                                {$option.label|escape:'htmlall':'UTF-8'}
+                                            </option>
+                                        {/foreach}
+                                    {/if}
+                                </select>
+                            {elseif $field.type == 'switch'}
+                                <span class="switch prestashop-switch fixed-width-lg">
+                                    <input type="radio" name="{$field.name|escape:'htmlall':'UTF-8'}" id="{$field.name|escape:'htmlall':'UTF-8'}_on" value="1" {if $field.value|default:0 == 1}checked="checked"{/if}>
+                                    <label for="{$field.name|escape:'htmlall':'UTF-8'}_on">{l s='Yes' d='Admin.Global'}</label>
+                                    <input type="radio" name="{$field.name|escape:'htmlall':'UTF-8'}" id="{$field.name|escape:'htmlall':'UTF-8'}_off" value="0" {if $field.value|default:0 == 0}checked="checked"{/if}>
+                                    <label for="{$field.name|escape:'htmlall':'UTF-8'}_off">{l s='No' d='Admin.Global'}</label>
+                                    <a class="slide-button btn"></a>
+                                </span>
+                            {elseif $field.type == 'file'}
+                                 <input type="file" name="{$field.name|escape:'htmlall':'UTF-8'}" id="{$field.name|escape:'htmlall':'UTF-8'}" class="form-control {if isset($field.class)}{$field.class|escape:'htmlall':'UTF-8'}{/if}" {if isset($field.accept)}accept="{$field.accept|escape:'htmlall':'UTF-8'}"{/if}>
+                                 {if isset($field.current_value_url) && $field.current_value_url}
+                                    <div style="margin-top:10px;">
+                                        <img src="{$field.current_value_url|escape:'htmlall':'UTF-8'}?rand={rand(0,1000)}" alt="{l s='Current Image' d='Modules.Mlthemebuilder.Admin'}" style="max-height:60px; border:1px solid #ddd;">
+                                        {if isset($field.current_value_filename) && $field.current_value_filename}
+                                            <input type="hidden" name="current_{$field.name|escape:'htmlall':'UTF-8'}" value="{$field.current_value_filename|escape:'htmlall':'UTF-8'}">
+                                        {/if}
+                                    </div>
+                                 {/if}
+                            {elseif $field.type == 'hidden'}
+                                <input type="hidden" name="{$field.name|escape:'htmlall':'UTF-8'}" value="{$field.value|default:''|escape:'htmlall':'UTF-8'}">
+                            {else}
+                                <!-- Other field types or custom HTML -->
+                                {$field.html_content nofilter}
+                            {/if}
+
+                            {if isset($field.desc) && $field.desc}
+                                <p class="help-block">{$field.desc|escape:'htmlall':'UTF-8'}</p>
+                            {/if}
+                        </div>
+                    </div>
+                {/foreach}
+            </div>
+            <div class="panel-footer">
+                <button type="submit" name="{$form_submit_name|default:'submitForm'|escape:'htmlall':'UTF-8'}" class="btn btn-default pull-right">
+                    <i class="process-icon-save"></i> {$form_submit_text|default:'Save'|escape:'htmlall':'UTF-8'}
+                </button>
+                {if isset($form_cancel_url) && $form_cancel_url}
+                    <a href="{$form_cancel_url|escape:'htmlall':'UTF-8'}" class="btn btn-default">
+                        <i class="process-icon-cancel"></i> {l s='Cancel' d='Admin.Actions'}
+                    </a>
+                {/if}
+            </div>
+        </div>
+    </form>
+{else}
+    <div class="alert alert-warning">{l s='No form fields defined for this helper.' d='Modules.Mlthemebuilder.Admin'}</div>
+{/if}

--- a/modules/mlthemebuilder/views/templates/admin/helpers/index.php
+++ b/modules/mlthemebuilder/views/templates/admin/helpers/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../'); // Redirect to modules/mlthemebuilder/views/templates/admin/
+exit;

--- a/modules/mlthemebuilder/views/templates/admin/helpers/list.tpl
+++ b/modules/mlthemebuilder/views/templates/admin/helpers/list.tpl
@@ -1,0 +1,130 @@
+{* This is a generic helper list template. Similar to form.tpl, it's more for manual list building
+   if not using PrestaShop's HelperList class. HelperList generates its own complex markup.
+   This demonstrates a basic list structure with Smarty.
+*}
+
+{if isset($list_title) && $list_title}
+    <div class="panel">
+        <div class="panel-heading">
+            <i class="icon-{$list_icon|default:'list'|escape:'htmlall':'UTF-8'}"></i> {$list_title|escape:'htmlall':'UTF-8'}
+            {if isset($add_new_url) && $add_new_url}
+                <span class="btn-group-action">
+                    <a href="{$add_new_url|escape:'htmlall':'UTF-8'}" class="btn btn-default">
+                        <i class="icon-plus"></i> {l s='Add new' d='Admin.Actions'}
+                    </a>
+                </span>
+            {/if}
+        </div>
+{/if}
+
+{if isset($list_items) && $list_items|count > 0}
+    <table class="table table-bordered table-striped {if isset($list_sortable) && $list_sortable}sortable{/if}">
+        <thead>
+            <tr>
+                {if isset($list_sortable) && $list_sortable}<th></th>{/if}
+                {foreach from=$list_headers item=header}
+                    <th>{$header.label|escape:'htmlall':'UTF-8'}</th>
+                {/foreach}
+                {if isset($list_actions) && $list_actions|count > 0}
+                    <th class="text-right">{l s='Actions' d='Admin.Global'}</th>
+                {/if}
+            </tr>
+        </thead>
+        <tbody {if isset($list_sortable) && $list_sortable}class="sortable-items" data-sort-url="{$sort_url|escape:'htmlall':'UTF-8'}"{/if}>
+            {foreach from=$list_items item=item}
+                <tr data-id="{$item.id|escape:'htmlall':'UTF-8'}">
+                    {if isset($list_sortable) && $list_sortable}
+                        <td class="dragHandle"><i class="icon-move"></i></td>
+                    {/if}
+                    {foreach from=$list_headers item=header}
+                        <td>
+                            {if $header.type == 'bool_status' && isset($item[$header.key])}
+                                <span class="label label-{if $item[$header.key]}success{else}danger{/if}">
+                                    {if $item[$header.key]}{l s='Yes' d='Admin.Global'}{else}{l s='No' d='Admin.Global'}{/if}
+                                </span>
+                            {elseif $header.type == 'image' && isset($item[$header.key])}
+                                <img src="{$item[$header.key]|escape:'htmlall':'UTF-8'}" alt="" style="max-height: 40px;">
+                            {else if isset($item[$header.key])}
+                                {$item[$header.key]|escape:'htmlall':'UTF-8'}
+                            {else}
+                                --
+                            {/if}
+                        </td>
+                    {/foreach}
+                    {if isset($list_actions) && $list_actions|count > 0}
+                        <td class="text-right">
+                            <div class="btn-group-action">
+                                <div class="btn-group">
+                                    {foreach from=$list_actions item=action}
+                                        {if $action.type == 'edit'}
+                                            <a href="{$action.url|replace:'ID_ITEM':$item.id|escape:'htmlall':'UTF-8'}" class="btn btn-default">
+                                                <i class="icon-pencil"></i> {l s='Edit' d='Admin.Actions'}
+                                            </a>
+                                        {elseif $action.type == 'delete'}
+                                            <a href="{$action.url|replace:'ID_ITEM':$item.id|escape:'htmlall':'UTF-8'}" class="btn btn-default list-action-delete" onclick="return confirm('{l s='Are you sure you want to delete this item?' d='Admin.Notifications.Warning'}');">
+                                                <i class="icon-trash"></i> {l s='Delete' d='Admin.Actions'}
+                                            </a>
+                                        {elseif $action.type == 'custom'}
+                                            <a href="{$action.url|replace:'ID_ITEM':$item.id|escape:'htmlall':'UTF-8'}" class="btn btn-default {$action.class|default:''|escape:'htmlall':'UTF-8'}" title="{$action.label|escape:'htmlall':'UTF-8'}">
+                                                <i class="icon-{$action.icon|default:'cog'|escape:'htmlall':'UTF-8'}"></i>
+                                                {if isset($action.label_visible) && $action.label_visible} {$action.label|escape:'htmlall':'UTF-8'}{/if}
+                                            </a>
+                                        {/if}
+                                    {/foreach}
+                                </div>
+                            </div>
+                        </td>
+                    {/if}
+                </tr>
+            {/foreach}
+        </tbody>
+    </table>
+{else}
+    <div class="alert alert-warning">{l s='No items found.' d='Modules.Mlthemebuilder.Admin'}</div>
+{/if}
+
+{if isset($list_title) && $list_title}
+    </div>
+{/if}
+
+{if isset($list_sortable) && $list_sortable}
+<script type="text/javascript">
+    $(function() {
+        $(".sortable-items").sortable({
+            handle: ".dragHandle",
+            placeholder: "ui-state-highlight",
+            axis: "y",
+            update: function(event, ui) {
+                var sortedIDs = $(this).sortable("toArray", { attribute: "data-id" });
+                var sortUrl = $(this).data('sort-url');
+                $.ajax({
+                    type: "POST",
+                    url: sortUrl, // This URL needs to handle the reordering
+                    data: {
+                        ajax: true,
+                        action: 'updatePositions', // Or your specific action
+                        order: sortedIDs
+                    },
+                    success: function(response) {
+                        // Handle success (e.g., show a notification)
+                        if(response.success) {
+                            showSuccessMessage(response.message || 'Order updated successfully.');
+                        } else {
+                            showErrorMessage(response.message || 'Error updating order.');
+                            $(".sortable-items").sortable('cancel'); // Revert on error
+                        }
+                    },
+                    error: function() {
+                        showErrorMessage('AJAX error updating order.');
+                        $(".sortable-items").sortable('cancel');
+                    }
+                });
+            }
+        }).disableSelection();
+    });
+</script>
+<style>
+    .dragHandle { cursor: move; }
+    .ui-state-highlight { height: 1.5em; line-height: 1.2em; background: #f0f0f0; border: 1px dashed #ccc; }
+</style>
+{/if}

--- a/modules/mlthemebuilder/views/templates/admin/index.php
+++ b/modules/mlthemebuilder/views/templates/admin/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../'); // Redirect to modules/mlthemebuilder/views/templates/
+exit;

--- a/modules/mlthemebuilder/views/templates/admin/sections/banner.tpl
+++ b/modules/mlthemebuilder/views/templates/admin/sections/banner.tpl
@@ -1,0 +1,135 @@
+{* Configuration form for Banner CTA Section *}
+<input type="hidden" name="config[type]" value="banner">
+
+{* Language tabs for multilingual fields *}
+{if $languages|count > 1}
+<div class="translations tabbable">
+    <ul class="nav nav-tabs">
+        {foreach from=$languages item=language}
+            <li class="nav-item {if $language.id_lang == $current_language.id_lang}active{/if}">
+                <a href="#banner_lang_{$language.id_lang|escape:'htmlall':'UTF-8'}" class="nav-link" data-toggle="tab">{$language.name|escape:'htmlall':'UTF-8'}</a>
+            </li>
+        {/foreach}
+    </ul>
+    <div class="tab-content">
+{/if}
+    {foreach from=$languages item=language}
+        {assign var=id_lang value=$language.id_lang}
+        <div class="tab-pane {if $id_lang == $current_language.id_lang}active{/if}" id="banner_lang_{$id_lang|escape:'htmlall':'UTF-8'}">
+            <div class="form-group">
+                <label class="control-label">{l s='Title' d='Modules.Mlthemebuilder.Admin'}</label>
+                <input type="text" name="title[{$id_lang|escape:'htmlall':'UTF-8'}]" class="form-control" value="{$section_data.titles[$id_lang]|default:''|escape:'htmlall':'UTF-8'}">
+            </div>
+
+            <div class="form-group">
+                <label class="control-label">{l s='Text/Content' d='Modules.Mlthemebuilder.Admin'}</label>
+                <textarea name="config[text_banner][{$id_lang|escape:'htmlall':'UTF-8'}]" class="form-control rte-admin" rows="4">{$section_data.config.text_banner[$id_lang]|default:''|escape:'htmlall':'UTF-8'}</textarea>
+                <p class="help-block">{l s='Main text content for the banner. HTML is allowed if RTE is enabled.' d='Modules.Mlthemebuilder.Admin'}</p>
+            </div>
+
+            <div class="form-group">
+                <label class="control-label">{l s='Button Text' d='Modules.Mlthemebuilder.Admin'}</label>
+                <input type="text" name="button_text[{$id_lang|escape:'htmlall':'UTF-8'}]" class="form-control" value="{$section_data.button_texts[$id_lang]|default:''|escape:'htmlall':'UTF-8'}">
+            </div>
+
+            <div class="form-group">
+                <label class="control-label">{l s='Button Link' d='Modules.Mlthemebuilder.Admin'}</label>
+                <input type="text" name="button_link[{$id_lang|escape:'htmlall':'UTF-8'}]" class="form-control" value="{$section_data.button_links[$id_lang]|default:'#'|escape:'htmlall':'UTF-8'}" placeholder="https://example.com/targetpage">
+            </div>
+        </div>
+    {/foreach}
+{if $languages|count > 1}
+    </div>
+</div>
+{/if}
+
+<hr>
+<h4>{l s='Appearance & Media' d='Modules.Mlthemebuilder.Admin'}</h4>
+
+<div class="form-group">
+    <label class="control-label">{l s='Layout Style' d='Modules.Mlthemebuilder.Admin'}</label>
+    <select name="config[layout_banner]" class="form-control">
+        <option value="image_right" {if $section_data.config.layout_banner|default:'image_right' == 'image_right'}selected{/if}>{l s='Text Left, Image Right' d='Modules.Mlthemebuilder.Admin'}</option>
+        <option value="image_left" {if $section_data.config.layout_banner|default:'' == 'image_left'}selected{/if}>{l s='Image Left, Text Right' d='Modules.Mlthemebuilder.Admin'}</option>
+        <option value="text_only" {if $section_data.config.layout_banner|default:'' == 'text_only'}selected{/if}>{l s='Text Only (Centered)' d='Modules.Mlthemebuilder.Admin'}</option>
+        <option value="image_background" {if $section_data.config.layout_banner|default:'' == 'image_background'}selected{/if}>{l s='Text Centered, Image as Full Background' d='Modules.Mlthemebuilder.Admin'}</option>
+    </select>
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Content Image (for layouts with image)' d='Modules.Mlthemebuilder.Admin'}</label>
+    <div class="input-group">
+        <input type="text" name="config[image_banner]" id="banner_image_path" class="form-control" value="{$section_data.config.image_banner|default:''|escape:'htmlall':'UTF-8'}" placeholder="{l s='e.g., cta_image.jpg' d='Modules.Mlthemebuilder.Admin'}">
+        <span class="input-group-btn">
+            <button type="button" class="btn btn-default btn-file-uploader" data-input-id="banner_image_path" data-preview-id="banner_image_preview" data-upload-type="section_image" data-section-id="{$section_data.id_section|escape:'htmlall':'UTF-8'}">
+                <i class="icon-upload"></i> {l s='Upload' d='Modules.Mlthemebuilder.Admin'}
+            </button>
+        </span>
+    </div>
+    {if isset($section_data.config.image_banner) && $section_data.config.image_banner}
+        <img id="banner_image_preview" src="{$theme_img_path|escape:'htmlall':'UTF-8'}sections/{$section_data.config.image_banner|escape:'htmlall':'UTF-8'}?rand={rand(0,1000)}" alt="{l s='Image Preview' d='Modules.Mlthemebuilder.Admin'}" class="img-thumbnail image-upload-preview">
+         <button type="button" class="btn btn-xs btn-danger remove-image-btn" data-input-id="banner_image_path" data-preview-id="banner_image_preview">{l s='Remove' d='Modules.Mlthemebuilder.Admin'}</button>
+    {else}
+        <img id="banner_image_preview" src="#" alt="{l s='Image Preview' d='Modules.Mlthemebuilder.Admin'}" class="img-thumbnail image-upload-preview hidden">
+        <button type="button" class="btn btn-xs btn-danger remove-image-btn hidden" data-input-id="banner_image_path" data-preview-id="banner_image_preview">{l s='Remove' d='Modules.Mlthemebuilder.Admin'}</button>
+    {/if}
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Background Color' d='Modules.Mlthemebuilder.Admin'}</label>
+    <input type="color" name="config[background_color_banner]" class="form-control color-picker" value="{$section_data.config.background_color_banner|default:'#ff6b6b'|escape:'htmlall':'UTF-8'}">
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Background Image (for layouts or full background)' d='Modules.Mlthemebuilder.Admin'}</label>
+     <div class="input-group">
+        <input type="text" name="config[background_image_banner]" id="banner_bg_image_path" class="form-control" value="{$section_data.config.background_image_banner|default:''|escape:'htmlall':'UTF-8'}" placeholder="{l s='e.g., banner_bg.jpg' d='Modules.Mlthemebuilder.Admin'}">
+        <span class="input-group-btn">
+            <button type="button" class="btn btn-default btn-file-uploader" data-input-id="banner_bg_image_path" data-preview-id="banner_bg_image_preview" data-upload-type="section_background" data-section-id="{$section_data.id_section|escape:'htmlall':'UTF-8'}">
+                <i class="icon-upload"></i> {l s='Upload' d='Modules.Mlthemebuilder.Admin'}
+            </button>
+        </span>
+    </div>
+    {if isset($section_data.config.background_image_banner) && $section_data.config.background_image_banner}
+        <img id="banner_bg_image_preview" src="{$theme_img_path|escape:'htmlall':'UTF-8'}sections/{$section_data.config.background_image_banner|escape:'htmlall':'UTF-8'}?rand={rand(0,1000)}" alt="{l s='Background Preview' d='Modules.Mlthemebuilder.Admin'}" class="img-thumbnail image-upload-preview">
+        <button type="button" class="btn btn-xs btn-danger remove-image-btn" data-input-id="banner_bg_image_path" data-preview-id="banner_bg_image_preview">{l s='Remove' d='Modules.Mlthemebuilder.Admin'}</button>
+    {else}
+        <img id="banner_bg_image_preview" src="#" alt="{l s='Background Preview' d='Modules.Mlthemebuilder.Admin'}" class="img-thumbnail image-upload-preview hidden">
+        <button type="button" class="btn btn-xs btn-danger remove-image-btn hidden" data-input-id="banner_bg_image_path" data-preview-id="banner_bg_image_preview">{l s='Remove' d='Modules.Mlthemebuilder.Admin'}</button>
+    {/if}
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Text Color (if background is dark or image)' d='Modules.Mlthemebuilder.Admin'}</label>
+    <input type="color" name="config[text_color_banner]" class="form-control color-picker" value="{$section_data.config.text_color_banner|default:'#ffffff'|escape:'htmlall':'UTF-8'}">
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Button Style' d='Modules.Mlthemebuilder.Admin'}</label>
+    <select name="config[button_style_banner]" class="form-control">
+        <option value="btn-primary" {if $section_data.config.button_style_banner|default:'btn-secondary' == 'btn-primary'}selected{/if}>{l s='Primary Button' d='Modules.Mlthemebuilder.Admin'}</option>
+        <option value="btn-secondary" {if $section_data.config.button_style_banner|default:'btn-secondary' == 'btn-secondary'}selected{/if}>{l s='Secondary Button' d='Modules.Mlthemebuilder.Admin'}</option>
+        <option value="btn-light" {if $section_data.config.button_style_banner|default:'' == 'btn-light'}selected{/if}>{l s='Light Button (for dark backgrounds)' d='Modules.Mlthemebuilder.Admin'}</option>
+        <option value="btn-outline-light" {if $section_data.config.button_style_banner|default:'' == 'btn-outline-light'}selected{/if}>{l s='Outline Light (for dark backgrounds)' d='Modules.Mlthemebuilder.Admin'}</option>
+    </select>
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Custom CSS Class' d='Modules.Mlthemebuilder.Admin'}</label>
+    <input type="text" name="config[custom_css_class]" class="form-control" value="{$section_data.config.custom_css_class|default:''|escape:'htmlall':'UTF-8'}">
+</div>
+
+<script type="text/javascript">
+    $('#section-modal-form-content .nav-tabs a').click(function (e) {
+        e.preventDefault();
+        $(this).tab('show');
+    });
+    $('#section-modal-form-content .nav-tabs li:first-child a').tab('show');
+    // Init RTE for textareas with class .rte-admin if function exists
+    if (typeof initTinyMCE !== 'undefined') {
+        initTinyMCE($('textarea.rte-admin'));
+    } else if (typeof tinyMCE !== 'undefined' && typeof tinyMCE.init !== 'undefined') {
+        // Fallback or manual init if initTinyMCE is not PS global
+        // tinyMCE.init({ selector: 'textarea.rte-admin', ... });
+    }
+</script>

--- a/modules/mlthemebuilder/views/templates/admin/sections/brands.tpl
+++ b/modules/mlthemebuilder/views/templates/admin/sections/brands.tpl
@@ -1,0 +1,102 @@
+{* Configuration form for Brands Section *}
+<input type="hidden" name="config[type]" value="brands">
+
+{* Language tabs for multilingual fields *}
+{if $languages|count > 1}
+<div class="translations tabbable">
+    <ul class="nav nav-tabs">
+        {foreach from=$languages item=language}
+            <li class="nav-item {if $language.id_lang == $current_language.id_lang}active{/if}">
+                <a href="#brands_lang_{$language.id_lang|escape:'htmlall':'UTF-8'}" class="nav-link" data-toggle="tab">{$language.name|escape:'htmlall':'UTF-8'}</a>
+            </li>
+        {/foreach}
+    </ul>
+    <div class="tab-content">
+{/if}
+    {foreach from=$languages item=language}
+        {assign var=id_lang value=$language.id_lang}
+        <div class="tab-pane {if $id_lang == $current_language.id_lang}active{/if}" id="brands_lang_{$id_lang|escape:'htmlall':'UTF-8'}">
+            <div class="form-group">
+                <label class="control-label">{l s='Section Title' d='Modules.Mlthemebuilder.Admin'}</label>
+                <input type="text" name="title[{$id_lang|escape:'htmlall':'UTF-8'}]" class="form-control" value="{$section_data.titles[$id_lang]|default:''|escape:'htmlall':'UTF-8'}" placeholder="{l s='e.g., Our Partners' d='Modules.Mlthemebuilder.Admin'}">
+            </div>
+        </div>
+    {/foreach}
+{if $languages|count > 1}
+    </div>
+</div>
+{/if}
+
+<hr>
+<h4>{l s='Slider Configuration' d='Modules.Mlthemebuilder.Admin'}</h4>
+
+<div class="form-group">
+    <label class="control-label">{l s='Animation Speed (duration for one full loop)' d='Modules.Mlthemebuilder.Admin'}</label>
+    <div class="input-group">
+        <input type="number" name="config[speed_brands]" class="form-control" value="{$section_data.config.speed_brands|default:30|escape:'htmlall':'UTF-8'}" min="5" max="120">
+        <span class="input-group-addon">{l s='seconds' d='Modules.Mlthemebuilder.Admin'}</span>
+    </div>
+    <p class="help-block">{l s='Lower value means faster animation.' d='Modules.Mlthemebuilder.Admin'}</p>
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Maximum Brands to Display' d='Modules.Mlthemebuilder.Admin'}</label>
+    <input type="number" name="config[max_brands]" class="form-control" value="{$section_data.config.max_brands|default:0|escape:'htmlall':'UTF-8'}" min="0" max="50">
+    <p class="help-block">{l s='Total number of brand logos to show in the slider. Leave empty or 0 for all active brands.' d='Modules.Mlthemebuilder.Admin'}</p>
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Pause on Hover' d='Modules.Mlthemebuilder.Admin'}</label>
+    <span class="switch prestashop-switch fixed-width-sm">
+        <input type="radio" name="config[pause_on_hover_brands]" id="pause_on_hover_brands_on" value="1" {if $section_data.config.pause_on_hover_brands|default:true}checked="checked"{/if}>
+        <label for="pause_on_hover_brands_on">{l s='Yes' d='Modules.Mlthemebuilder.Admin'}</label>
+        <input type="radio" name="config[pause_on_hover_brands]" id="pause_on_hover_brands_off" value="0" {if !$section_data.config.pause_on_hover_brands|default:true}checked="checked"{/if}>
+        <label for="pause_on_hover_brands_off">{l s='No' d='Modules.Mlthemebuilder.Admin'}</label>
+        <a class="slide-button btn"></a>
+    </span>
+    <p class="help-block">{l s='Pause the slider animation when the mouse is over it.' d='Modules.Mlthemebuilder.Admin'}</p>
+</div>
+
+<div class="alert alert-info">
+    <i class="icon-info-sign"></i>
+    {l s='Brand logos and their links are managed globally under the "Manage Brands" tab in the module configuration.' d='Modules.Mlthemebuilder.Admin'}
+    {l s='This section will display active brands based on their order.' d='Modules.Mlthemebuilder.Admin'}
+</div>
+
+<hr>
+<h4>{l s='Appearance' d='Modules.Mlthemebuilder.Admin'}</h4>
+<div class="form-group">
+    <label class="control-label">{l s='Background Color' d='Modules.Mlthemebuilder.Admin'}</label>
+    <input type="color" name="config[background_color_brands]" class="form-control color-picker" value="{$section_data.config.background_color_brands|default:'#f8f9fa'|escape:'htmlall':'UTF-8'}">
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Logo Style' d='Modules.Mlthemebuilder.Admin'}</label>
+    <select name="config[logo_style_brands]" class="form-control">
+        <option value="grayscale_hover_color" {if $section_data.config.logo_style_brands|default:'grayscale_hover_color' == 'grayscale_hover_color'}selected{/if}>{l s='Grayscale, Color on Hover' d='Modules.Mlthemebuilder.Admin'}</option>
+        <option value="color" {if $section_data.config.logo_style_brands|default:'' == 'color'}selected{/if}>{l s='Full Color' d='Modules.Mlthemebuilder.Admin'}</option>
+        <option value="grayscale" {if $section_data.config.logo_style_brands|default:'' == 'grayscale'}selected{/if}>{l s='Always Grayscale' d='Modules.Mlthemebuilder.Admin'}</option>
+    </select>
+    <p class="help-block">{l s='Visual style for the brand logos.' d='Modules.Mlthemebuilder.Admin'}</p>
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Logo Max Height' d='Modules.Mlthemebuilder.Admin'}</label>
+    <div class="input-group">
+        <input type="number" name="config[logo_max_height_brands]" class="form-control" value="{$section_data.config.logo_max_height_brands|default:60|escape:'htmlall':'UTF-8'}" min="20" max="150">
+        <span class="input-group-addon">{l s='px' d='Modules.Mlthemebuilder.Admin'}</span>
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Custom CSS Class' d='Modules.Mlthemebuilder.Admin'}</label>
+    <input type="text" name="config[custom_css_class]" class="form-control" value="{$section_data.config.custom_css_class|default:''|escape:'htmlall':'UTF-8'}">
+</div>
+
+<script type="text/javascript">
+    $('#section-modal-form-content .nav-tabs a').click(function (e) {
+        e.preventDefault();
+        $(this).tab('show');
+    });
+    $('#section-modal-form-content .nav-tabs li:first-child a').tab('show');
+</script>

--- a/modules/mlthemebuilder/views/templates/admin/sections/contact.tpl
+++ b/modules/mlthemebuilder/views/templates/admin/sections/contact.tpl
@@ -1,0 +1,145 @@
+{* Configuration form for Contact Section *}
+<input type="hidden" name="config[type]" value="contact">
+
+{* Language tabs for multilingual fields *}
+{if $languages|count > 1}
+<div class="translations tabbable">
+    <ul class="nav nav-tabs">
+        {foreach from=$languages item=language}
+            <li class="nav-item {if $language.id_lang == $current_language.id_lang}active{/if}">
+                <a href="#contact_lang_{$language.id_lang|escape:'htmlall':'UTF-8'}" class="nav-link" data-toggle="tab">{$language.name|escape:'htmlall':'UTF-8'}</a>
+            </li>
+        {/foreach}
+    </ul>
+    <div class="tab-content">
+{/if}
+    {foreach from=$languages item=language}
+        {assign var=id_lang value=$language.id_lang}
+        <div class="tab-pane {if $id_lang == $current_language.id_lang}active{/if}" id="contact_lang_{$id_lang|escape:'htmlall':'UTF-8'}">
+            <div class="form-group">
+                <label class="control-label">{l s='Section Title' d='Modules.Mlthemebuilder.Admin'}</label>
+                <input type="text" name="title[{$id_lang|escape:'htmlall':'UTF-8'}]" class="form-control" value="{$section_data.titles[$id_lang]|default:''|escape:'htmlall':'UTF-8'}">
+            </div>
+
+            <div class="form-group">
+                <label class="control-label">{l s='Address' d='Modules.Mlthemebuilder.Admin'}</label>
+                <textarea name="config[address_contact][{$id_lang|escape:'htmlall':'UTF-8'}]" class="form-control" rows="2">{$section_data.config.address_contact[$id_lang]|default:''|escape:'htmlall':'UTF-8'}</textarea>
+                <p class="help-block">{l s='Shop address. Supports multiple lines.' d='Modules.Mlthemebuilder.Admin'}</p>
+            </div>
+
+            <div class="form-group">
+                <label class="control-label">{l s='Phone Number' d='Modules.Mlthemebuilder.Admin'}</label>
+                <input type="text" name="config[phone_contact][{$id_lang|escape:'htmlall':'UTF-8'}]" class="form-control" value="{$section_data.config.phone_contact[$id_lang]|default:''|escape:'htmlall':'UTF-8'}">
+            </div>
+
+            <div class="form-group">
+                <label class="control-label">{l s='Email Address' d='Modules.Mlthemebuilder.Admin'}</label>
+                <input type="email" name="config[email_contact][{$id_lang|escape:'htmlall':'UTF-8'}]" class="form-control" value="{$section_data.config.email_contact[$id_lang]|default:''|escape:'htmlall':'UTF-8'}">
+            </div>
+
+            <div class="form-group">
+                <label class="control-label">{l s='Opening Hours' d='Modules.Mlthemebuilder.Admin'}</label>
+                <textarea name="config[hours_contact][{$id_lang|escape:'htmlall':'UTF-8'}]" class="form-control" rows="3">{$section_data.config.hours_contact[$id_lang]|default:''|escape:'htmlall':'UTF-8'}</textarea>
+                <p class="help-block">{l s='e.g., Mon-Fri: 9am-5pm, Sat: 10am-2pm. Supports multiple lines.' d='Modules.Mlthemebuilder.Admin'}</p>
+            </div>
+        </div>
+    {/foreach}
+{if $languages|count > 1}
+    </div>
+</div>
+{/if}
+
+<hr>
+<h4>{l s='Features' d='Modules.Mlthemebuilder.Admin'}</h4>
+<div class="form-group">
+    <label class="control-label">{l s='Show Contact Form' d='Modules.Mlthemebuilder.Admin'}</label>
+    <span class="switch prestashop-switch fixed-width-sm">
+        <input type="radio" name="config[show_form_contact]" id="show_form_contact_on" value="1" {if $section_data.config.show_form_contact|default:true}checked="checked"{/if}>
+        <label for="show_form_contact_on">{l s='Yes' d='Modules.Mlthemebuilder.Admin'}</label>
+        <input type="radio" name="config[show_form_contact]" id="show_form_contact_off" value="0" {if !$section_data.config.show_form_contact|default:true}checked="checked"{/if}>
+        <label for="show_form_contact_off">{l s='No' d='Modules.Mlthemebuilder.Admin'}</label>
+        <a class="slide-button btn"></a>
+    </span>
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Enable CAPTCHA on Form (if available)' d='Modules.Mlthemebuilder.Admin'}</label>
+    <span class="switch prestashop-switch fixed-width-sm">
+        <input type="radio" name="config[enable_captcha_contact]" id="enable_captcha_contact_on" value="1" {if $section_data.config.enable_captcha_contact|default:false}checked="checked"{/if}>
+        <label for="enable_captcha_contact_on">{l s='Yes' d='Modules.Mlthemebuilder.Admin'}</label>
+        <input type="radio" name="config[enable_captcha_contact]" id="enable_captcha_contact_off" value="0" {if !$section_data.config.enable_captcha_contact|default:false}checked="checked"{/if}>
+        <label for="enable_captcha_contact_off">{l s='No' d='Modules.Mlthemebuilder.Admin'}</label>
+        <a class="slide-button btn"></a>
+    </span>
+    <p class="help-block">{l s='Requires a CAPTCHA module to be installed and configured, or manual integration.' d='Modules.Mlthemebuilder.Admin'}</p>
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Show Map' d='Modules.Mlthemebuilder.Admin'}</label>
+    <span class="switch prestashop-switch fixed-width-sm">
+        <input type="radio" name="config[show_map_contact]" id="show_map_contact_on" value="1" {if $section_data.config.show_map_contact|default:false}checked="checked"{/if}>
+        <label for="show_map_contact_on">{l s='Yes' d='Modules.Mlthemebuilder.Admin'}</label>
+        <input type="radio" name="config[show_map_contact]" id="show_map_contact_off" value="0" {if !$section_data.config.show_map_contact|default:false}checked="checked"{/if}>
+        <label for="show_map_contact_off">{l s='No' d='Modules.Mlthemebuilder.Admin'}</label>
+        <a class="slide-button btn"></a>
+    </span>
+</div>
+<div class="form-group" id="map_embed_code_group" {if !$section_data.config.show_map_contact|default:false}style="display:none;"{/if}>
+    <label class="control-label">{l s='Map Embed Code (HTML)' d='Modules.Mlthemebuilder.Admin'}</label>
+    <textarea name="config[map_embed_code_contact]" class="form-control" rows="4" placeholder="{l s='e.g., <iframe src=...></iframe> from Google Maps' d='Modules.Mlthemebuilder.Admin'}">{$section_data.config.map_embed_code_contact|default:''|escape:'htmlall':'UTF-8'}</textarea>
+    <p class="help-block">{l s='Paste the HTML embed code for your map (e.g., from Google Maps).' d='Modules.Mlthemebuilder.Admin'}</p>
+</div>
+
+<hr>
+<h4>{l s='Appearance' d='Modules.Mlthemebuilder.Admin'}</h4>
+<div class="form-group">
+    <label class="control-label">{l s='Background Color' d='Modules.Mlthemebuilder.Admin'}</label>
+    <input type="color" name="config[background_color_contact]" class="form-control color-picker" value="{$section_data.config.background_color_contact|default:'#333333'|escape:'htmlall':'UTF-8'}">
+</div>
+<div class="form-group">
+    <label class="control-label">{l s='Text Color' d='Modules.Mlthemebuilder.Admin'}</label>
+    <input type="color" name="config[text_color_contact]" class="form-control color-picker" value="{$section_data.config.text_color_contact|default:'#ffffff'|escape:'htmlall':'UTF-8'}">
+</div>
+<div class="form-group">
+    <label class="control-label">{l s='Background Image' d='Modules.Mlthemebuilder.Admin'}</label>
+     <div class="input-group">
+        <input type="text" name="config[background_image_contact]" id="contact_bg_image_path" class="form-control" value="{$section_data.config.background_image_contact|default:''|escape:'htmlall':'UTF-8'}" placeholder="{l s='e.g., contact_bg.jpg' d='Modules.Mlthemebuilder.Admin'}">
+        <span class="input-group-btn">
+            <button type="button" class="btn btn-default btn-file-uploader" data-input-id="contact_bg_image_path" data-preview-id="contact_bg_image_preview" data-upload-type="section_background" data-section-id="{$section_data.id_section|escape:'htmlall':'UTF-8'}">
+                <i class="icon-upload"></i> {l s='Upload' d='Modules.Mlthemebuilder.Admin'}
+            </button>
+        </span>
+    </div>
+    {if isset($section_data.config.background_image_contact) && $section_data.config.background_image_contact}
+        <img id="contact_bg_image_preview" src="{$theme_img_path|escape:'htmlall':'UTF-8'}sections/{$section_data.config.background_image_contact|escape:'htmlall':'UTF-8'}?rand={rand(0,1000)}" alt="{l s='Background Preview' d='Modules.Mlthemebuilder.Admin'}" class="img-thumbnail image-upload-preview">
+        <button type="button" class="btn btn-xs btn-danger remove-image-btn" data-input-id="contact_bg_image_path" data-preview-id="contact_bg_image_preview">{l s='Remove' d='Modules.Mlthemebuilder.Admin'}</button>
+    {else}
+        <img id="contact_bg_image_preview" src="#" alt="{l s='Background Preview' d='Modules.Mlthemebuilder.Admin'}" class="img-thumbnail image-upload-preview hidden">
+        <button type="button" class="btn btn-xs btn-danger remove-image-btn hidden" data-input-id="contact_bg_image_path" data-preview-id="contact_bg_image_preview">{l s='Remove' d='Modules.Mlthemebuilder.Admin'}</button>
+    {/if}
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Custom CSS Class' d='Modules.Mlthemebuilder.Admin'}</label>
+    <input type="text" name="config[custom_css_class]" class="form-control" value="{$section_data.config.custom_css_class|default:''|escape:'htmlall':'UTF-8'}">
+</div>
+
+<script type="text/javascript">
+$(document).ready(function() {
+    function toggleMapEmbed() {
+        if ($('input[name="config[show_map_contact]"]:checked').val() == '1') {
+            $('#map_embed_code_group').show();
+        } else {
+            $('#map_embed_code_group').hide();
+        }
+    }
+    $('input[name="config[show_map_contact]"]').on('change', toggleMapEmbed);
+    toggleMapEmbed(); // Initial call
+
+    $('#section-modal-form-content .nav-tabs a').click(function (e) {
+        e.preventDefault();
+        $(this).tab('show');
+    });
+    $('#section-modal-form-content .nav-tabs li:first-child a').tab('show');
+});
+</script>

--- a/modules/mlthemebuilder/views/templates/admin/sections/custom_html.tpl
+++ b/modules/mlthemebuilder/views/templates/admin/sections/custom_html.tpl
@@ -1,0 +1,109 @@
+{* Configuration form for Custom HTML Section *}
+{* This section allows direct HTML input, so it needs careful handling and potentially sanitization options or warnings. *}
+<input type="hidden" name="config[type]" value="custom_html">
+
+{* Language tabs for multilingual fields *}
+{if $languages|count > 1}
+<div class="translations tabbable">
+    <ul class="nav nav-tabs">
+        {foreach from=$languages item=language}
+            <li class="nav-item {if $language.id_lang == $current_language.id_lang}active{/if}">
+                <a href="#custom_html_lang_{$language.id_lang|escape:'htmlall':'UTF-8'}" class="nav-link" data-toggle="tab">{$language.name|escape:'htmlall':'UTF-8'}</a>
+            </li>
+        {/foreach}
+    </ul>
+    <div class="tab-content">
+{/if}
+    {foreach from=$languages item=language}
+        {assign var=id_lang value=$language.id_lang}
+        <div class="tab-pane {if $id_lang == $current_language.id_lang}active{/if}" id="custom_html_lang_{$id_lang|escape:'htmlall':'UTF-8'}">
+            <div class="form-group">
+                <label class="control-label">{l s='Section Title (Optional, for Admin only)' d='Modules.Mlthemebuilder.Admin'}</label>
+                <input type="text" name="title[{$id_lang|escape:'htmlall':'UTF-8'}]" class="form-control" value="{$section_data.titles[$id_lang]|default:''|escape:'htmlall':'UTF-8'}" placeholder="{l s='e.g., Special Promotion Block' d='Modules.Mlthemebuilder.Admin'}">
+                <p class="help-block">{l s='This title is for your reference in the admin panel and is not displayed on the frontend unless your custom HTML includes it.' d='Modules.Mlthemebuilder.Admin'}</p>
+            </div>
+
+            <div class="form-group">
+                <label class="control-label">{l s='Custom HTML Content' d='Modules.Mlthemebuilder.Admin'}</label>
+                <textarea name="config[custom_html_content][{$id_lang|escape:'htmlall':'UTF-8'}]" class="form-control code codemirror-html" data-editor-mode="htmlmixed" rows="15">{$section_data.config.custom_html_content[$id_lang]|default:''|escape:'htmlall':'UTF-8'}</textarea> {/* Note: Escaping here for safety in textarea, but on output it will be raw HTML */}
+                <p class="help-block">
+                    {l s='Enter your custom HTML code here. Be careful, as incorrect HTML/JS can break your site.' d='Modules.Mlthemebuilder.Admin'}
+                    {l s='You can use Smarty variables available in the frontend context (e.g., {$shop.name}, {$urls.base_url}).' d='Modules.Mlthemebuilder.Admin'}
+                    {l s='If using <script> tags, ensure they are correctly formatted and secure.' d='Modules.Mlthemebuilder.Admin'}
+                </p>
+            </div>
+        </div>
+    {/foreach}
+{if $languages|count > 1}
+    </div>
+</div>
+{/if}
+
+<hr>
+<h4>{l s='Appearance & Options' d='Modules.Mlthemebuilder.Admin'}</h4>
+
+<div class="form-group">
+    <label class="control-label">{l s='Full Width Section' d='Modules.Mlthemebuilder.Admin'}</label>
+    <span class="switch prestashop-switch fixed-width-sm">
+        <input type="radio" name="config[full_width_custom_html]" id="full_width_custom_html_on" value="1" {if $section_data.config.full_width_custom_html|default:false}checked="checked"{/if}>
+        <label for="full_width_custom_html_on">{l s='Yes' d='Modules.Mlthemebuilder.Admin'}</label>
+        <input type="radio" name="config[full_width_custom_html]" id="full_width_custom_html_off" value="0" {if !$section_data.config.full_width_custom_html|default:false}checked="checked"{/if}>
+        <label for="full_width_custom_html_off">{l s='No' d='Modules.Mlthemebuilder.Admin'}</label>
+        <a class="slide-button btn"></a>
+    </span>
+    <p class="help-block">{l s='If No, content will be wrapped in a standard container. If Yes, it spans the full browser width (you control container inside your HTML).' d='Modules.Mlthemebuilder.Admin'}</p>
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Remove Section Padding' d='Modules.Mlthemebuilder.Admin'}</label>
+    <span class="switch prestashop-switch fixed-width-sm">
+        <input type="radio" name="config[no_padding_custom_html]" id="no_padding_custom_html_on" value="1" {if $section_data.config.no_padding_custom_html|default:false}checked="checked"{/if}>
+        <label for="no_padding_custom_html_on">{l s='Yes' d='Modules.Mlthemebuilder.Admin'}</label>
+        <input type="radio" name="config[no_padding_custom_html]" id="no_padding_custom_html_off" value="0" {if !$section_data.config.no_padding_custom_html|default:false}checked="checked"{/if}>
+        <label for="no_padding_custom_html_off">{l s='No' d='Modules.Mlthemebuilder.Admin'}</label>
+        <a class="slide-button btn"></a>
+    </span>
+    <p class="help-block">{l s='If Yes, removes the default top/bottom padding of the section wrapper. Useful for full-bleed designs.' d='Modules.Mlthemebuilder.Admin'}</p>
+</div>
+
+
+<div class="form-group">
+    <label class="control-label">{l s='Background Color' d='Modules.Mlthemebuilder.Admin'}</label>
+    <input type="color" name="config[background_color_custom_html]" class="form-control color-picker" value="{$section_data.config.background_color_custom_html|default:'#ffffff'|escape:'htmlall':'UTF-8'}">
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Custom CSS Class for this Section' d='Modules.Mlthemebuilder.Admin'}</label>
+    <input type="text" name="config[custom_css_class]" class="form-control" value="{$section_data.config.custom_css_class|default:''|escape:'htmlall':'UTF-8'}" placeholder="{l s='e.g., my-unique-html-block' d='Modules.Mlthemebuilder.Admin'}">
+</div>
+
+<div class="alert alert-warning">
+    <strong>{l s='Security Warning:' d='Modules.Mlthemebuilder.Admin'}</strong>
+    {l s='Allowing arbitrary HTML and JavaScript can be a security risk if non-trusted users have access to this configuration. Ensure that only trusted administrators can edit this section.' d='Modules.Mlthemebuilder.Admin'}
+    {l s='This module does not sanitize the Custom HTML content by default to provide maximum flexibility. You are responsible for the security of the code you input.' d='Modules.Mlthemebuilder.Admin'}
+</div>
+
+<script type="text/javascript">
+$(document).ready(function() {
+    // Initialize CodeMirror or similar for HTML editing if available
+    // This is a generic placeholder; actual CodeMirror init is more complex
+    if (typeof CodeMirror !== 'undefined') {
+        $('textarea.codemirror-html').each(function(){
+            var editor = CodeMirror.fromTextArea(this, {
+                mode: $(this).data('editor-mode') || "htmlmixed",
+                lineNumbers: true,
+                theme: "default", // or your preferred theme
+                // ... other CodeMirror options
+            });
+            // Refresh editor if modal is resized or shown (if it was hidden)
+            // $('#sectionConfigurationModal').on('shown.bs.modal', function () { editor.refresh(); });
+        });
+    }
+
+    $('#section-modal-form-content .nav-tabs a').click(function (e) {
+        e.preventDefault();
+        $(this).tab('show');
+    });
+     $('#section-modal-form-content .nav-tabs li:first-child a').tab('show');
+});
+</script>

--- a/modules/mlthemebuilder/views/templates/admin/sections/ecology.tpl
+++ b/modules/mlthemebuilder/views/templates/admin/sections/ecology.tpl
@@ -1,0 +1,162 @@
+{* Configuration form for Ecology Section *}
+<input type="hidden" name="config[type]" value="ecology">
+
+{* Language tabs for multilingual fields *}
+{if $languages|count > 1}
+<div class="translations tabbable">
+    <ul class="nav nav-tabs">
+        {foreach from=$languages item=language}
+            <li class="nav-item {if $language.id_lang == $current_language.id_lang}active{/if}">
+                <a href="#ecology_lang_{$language.id_lang|escape:'htmlall':'UTF-8'}" class="nav-link" data-toggle="tab">{$language.name|escape:'htmlall':'UTF-8'}</a>
+            </li>
+        {/foreach}
+    </ul>
+    <div class="tab-content">
+{/if}
+    {foreach from=$languages item=language}
+        {assign var=id_lang value=$language.id_lang}
+        <div class="tab-pane {if $id_lang == $current_language.id_lang}active{/if}" id="ecology_lang_{$id_lang|escape:'htmlall':'UTF-8'}">
+            <div class="form-group">
+                <label class="control-label">{l s='Title' d='Modules.Mlthemebuilder.Admin'}</label>
+                <input type="text" name="title[{$id_lang|escape:'htmlall':'UTF-8'}]" class="form-control" value="{$section_data.titles[$id_lang]|default:''|escape:'htmlall':'UTF-8'}">
+            </div>
+
+            <div class="form-group">
+                <label class="control-label">{l s='Text/Description' d='Modules.Mlthemebuilder.Admin'}</label>
+                <textarea name="config[text_ecology][{$id_lang|escape:'htmlall':'UTF-8'}]" class="form-control rte-admin" rows="5">{$section_data.config.text_ecology[$id_lang]|default:''|escape:'htmlall':'UTF-8'}</textarea>
+            </div>
+
+            {* Repeatable items configuration will be handled below, outside language loop for structure, inside for text *}
+        </div>
+    {/foreach}
+{if $languages|count > 1}
+    </div>
+</div>
+{/if}
+
+<hr>
+<h4>{l s='Ecology Items' d='Modules.Mlthemebuilder.Admin'}</h4>
+<div id="ecology-items-container" class="repeatable-item-container">
+    {assign var=ecology_items value=$section_data.config.items_ecology|default:[]}
+    {if $ecology_items|count > 0}
+        {foreach from=$ecology_items item=item key=item_key}
+            <div class="ecology-item-instance repeatable-item" data-index="{$item_key|escape:'htmlall':'UTF-8'}">
+                <div class="repeatable-item-header">
+                    <h5>{l s='Item' d='Modules.Mlthemebuilder.Admin'} #<span class="item-index">{$item_key+1|escape:'htmlall':'UTF-8'}</span></h5>
+                    <button type="button" class="btn btn-danger btn-xs remove-ecology-item remove-repeatable-item"><i class="icon-trash"></i></button>
+                </div>
+                <div class="form-group">
+                    <label class="control-label">{l s='Icon' d='Modules.Mlthemebuilder.Admin'}</label>
+                    <input type="text" name="config[items_ecology][{$item_key|escape:'htmlall':'UTF-8'}][icon]" class="form-control" value="{$item.icon|default:''|escape:'htmlall':'UTF-8'}" placeholder="{l s='e.g., fas fa-leaf or icon.png' d='Modules.Mlthemebuilder.Admin'}">
+                    <p class="help-block">{l s='FontAwesome class or filename from /views/img/icons/' d='Modules.Mlthemebuilder.Admin'}</p>
+                </div>
+                {foreach from=$languages item=language}
+                    {assign var=id_lang_item value=$language.id_lang}
+                    <div class="form-group">
+                        <label class="control-label">{l s='Text' d='Modules.Mlthemebuilder.Admin'} ({$language.iso_code|escape:'htmlall':'UTF-8'})</label>
+                        <input type="text" name="config[items_ecology][{$item_key|escape:'htmlall':'UTF-8'}][text][{$id_lang_item|escape:'htmlall':'UTF-8'}]" class="form-control" value="{$item.text[$id_lang_item]|default:''|escape:'htmlall':'UTF-8'}">
+                    </div>
+                {/foreach}
+            </div>
+        {/foreach}
+    {else}
+        <p class="text-muted no-ecology-items">{l s='No ecology items added yet.' d='Modules.Mlthemebuilder.Admin'}</p>
+    {/if}
+</div>
+<button type="button" id="add-ecology-item" class="btn btn-default add-repeatable-item"><i class="icon-plus"></i> {l s='Add Ecology Item' d='Modules.Mlthemebuilder.Admin'}</button>
+
+{* Template for new ecology items (for JS) *}
+<div id="ecology-item-template" style="display:none;">
+    <div class="ecology-item-instance repeatable-item" data-index="{index}">
+        <div class="repeatable-item-header">
+             <h5>{l s='Item' d='Modules.Mlthemebuilder.Admin'} #<span class="item-index">{display_index}</span></h5>
+            <button type="button" class="btn btn-danger btn-xs remove-ecology-item remove-repeatable-item"><i class="icon-trash"></i></button>
+        </div>
+        <div class="form-group">
+            <label class="control-label">{l s='Icon' d='Modules.Mlthemebuilder.Admin'}</label>
+            <input type="text" name="config[items_ecology][{index}][icon]" class="form-control" placeholder="{l s='e.g., fas fa-leaf or icon.png' d='Modules.Mlthemebuilder.Admin'}">
+            <p class="help-block">{l s='FontAwesome class or filename from /views/img/icons/' d='Modules.Mlthemebuilder.Admin'}</p>
+        </div>
+        {foreach from=$languages item=language}
+            {assign var=id_lang_template value=$language.id_lang}
+            <div class="form-group">
+                <label class="control-label">{l s='Text' d='Modules.Mlthemebuilder.Admin'} ({$language.iso_code|escape:'htmlall':'UTF-8'})</label>
+                <input type="text" name="config[items_ecology][{index}][text][{$id_lang_template|escape:'htmlall':'UTF-8'}]" class="form-control">
+            </div>
+        {/foreach}
+    </div>
+</div>
+
+
+<hr>
+<h4>{l s='Appearance & Media' d='Modules.Mlthemebuilder.Admin'}</h4>
+
+<div class="form-group">
+    <label class="control-label">{l s='Layout Style' d='Modules.Mlthemebuilder.Admin'}</label>
+    <select name="config[layout_ecology]" class="form-control">
+        <option value="image_right" {if $section_data.config.layout_ecology|default:'image_right' == 'image_right'}selected{/if}>{l s='Text Left, Image Right' d='Modules.Mlthemebuilder.Admin'}</option>
+        <option value="image_left" {if $section_data.config.layout_ecology|default:'' == 'image_left'}selected{/if}>{l s='Image Left, Text Right' d='Modules.Mlthemebuilder.Admin'}</option>
+    </select>
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Image' d='Modules.Mlthemebuilder.Admin'}</label>
+    <div class="input-group">
+        <input type="text" name="config[image_ecology]" id="ecology_image_path" class="form-control" value="{$section_data.config.image_ecology|default:''|escape:'htmlall':'UTF-8'}" placeholder="{l s='e.g., ecology_image.jpg' d='Modules.Mlthemebuilder.Admin'}">
+        <span class="input-group-btn">
+            <button type="button" class="btn btn-default btn-file-uploader" data-input-id="ecology_image_path" data-preview-id="ecology_image_preview" data-upload-type="section_image" data-section-id="{$section_data.id_section|escape:'htmlall':'UTF-8'}">
+                <i class="icon-upload"></i> {l s='Upload' d='Modules.Mlthemebuilder.Admin'}
+            </button>
+        </span>
+    </div>
+    {if isset($section_data.config.image_ecology) && $section_data.config.image_ecology}
+        <img id="ecology_image_preview" src="{$theme_img_path|escape:'htmlall':'UTF-8'}sections/{$section_data.config.image_ecology|escape:'htmlall':'UTF-8'}?rand={rand(0,1000)}" alt="{l s='Image Preview' d='Modules.Mlthemebuilder.Admin'}" class="img-thumbnail image-upload-preview">
+        <button type="button" class="btn btn-xs btn-danger remove-image-btn" data-input-id="ecology_image_path" data-preview-id="ecology_image_preview">{l s='Remove' d='Modules.Mlthemebuilder.Admin'}</button>
+    {else}
+        <img id="ecology_image_preview" src="#" alt="{l s='Image Preview' d='Modules.Mlthemebuilder.Admin'}" class="img-thumbnail image-upload-preview hidden">
+        <button type="button" class="btn btn-xs btn-danger remove-image-btn hidden" data-input-id="ecology_image_path" data-preview-id="ecology_image_preview">{l s='Remove' d='Modules.Mlthemebuilder.Admin'}</button>
+    {/if}
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Background Color' d='Modules.Mlthemebuilder.Admin'}</label>
+    <input type="color" name="config[background_color_ecology]" class="form-control color-picker" value="{$section_data.config.background_color_ecology|default:'#e8f5e8'|escape:'htmlall':'UTF-8'}">
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Custom CSS Class' d='Modules.Mlthemebuilder.Admin'}</label>
+    <input type="text" name="config[custom_css_class]" class="form-control" value="{$section_data.config.custom_css_class|default:''|escape:'htmlall':'UTF-8'}">
+</div>
+
+<script type="text/javascript">
+$(document).ready(function() {
+    var ecologyItemIndex = {$ecology_items|count}; // Start index from current number of items
+
+    $('#add-ecology-item').on('click', function() {
+        var template = $('#ecology-item-template').html();
+        template = template.replace(/{index}/g, ecologyItemIndex)
+                           .replace(/{display_index}/g, ecologyItemIndex + 1);
+        $('#ecology-items-container').append(template);
+        $('.no-ecology-items').hide(); // Hide "no items" message
+        ecologyItemIndex++;
+    });
+
+    $('#ecology-items-container').on('click', '.remove-ecology-item', function() {
+        $(this).closest('.ecology-item-instance').remove();
+        // Renumber items is complex, usually not needed if server handles array keys correctly
+        // If no items left, show "no items" message
+        if ($('#ecology-items-container .ecology-item-instance').length === 0) {
+            $('.no-ecology-items').show();
+        }
+    });
+
+    $('#section-modal-form-content .nav-tabs a').click(function (e) {
+        e.preventDefault();
+        $(this).tab('show');
+    });
+    $('#section-modal-form-content .nav-tabs li:first-child a').tab('show');
+    if (typeof initTinyMCE !== 'undefined') {
+        initTinyMCE($('textarea.rte-admin'));
+    }
+});
+</script>

--- a/modules/mlthemebuilder/views/templates/admin/sections/index.php
+++ b/modules/mlthemebuilder/views/templates/admin/sections/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../'); // Redirect to modules/mlthemebuilder/views/templates/admin/
+exit;

--- a/modules/mlthemebuilder/views/templates/admin/sections/products.tpl
+++ b/modules/mlthemebuilder/views/templates/admin/sections/products.tpl
@@ -1,0 +1,154 @@
+{* Configuration form for Products Section *}
+<input type="hidden" name="config[type]" value="products">
+
+{* Language tabs for multilingual fields *}
+{if $languages|count > 1}
+<div class="translations tabbable">
+    <ul class="nav nav-tabs">
+        {foreach from=$languages item=language}
+            <li class="nav-item {if $language.id_lang == $current_language.id_lang}active{/if}">
+                <a href="#products_lang_{$language.id_lang|escape:'htmlall':'UTF-8'}" class="nav-link" data-toggle="tab">{$language.name|escape:'htmlall':'UTF-8'}</a>
+            </li>
+        {/foreach}
+    </ul>
+    <div class="tab-content">
+{/if}
+    {foreach from=$languages item=language}
+        {assign var=id_lang value=$language.id_lang}
+        <div class="tab-pane {if $id_lang == $current_language.id_lang}active{/if}" id="products_lang_{$id_lang|escape:'htmlall':'UTF-8'}">
+            <div class="form-group">
+                <label class="control-label">{l s='Section Title' d='Modules.Mlthemebuilder.Admin'}</label>
+                <input type="text" name="title[{$id_lang|escape:'htmlall':'UTF-8'}]" class="form-control" value="{$section_data.titles[$id_lang]|default:''|escape:'htmlall':'UTF-8'}" placeholder="{l s='e.g., Our Products' d='Modules.Mlthemebuilder.Admin'}">
+            </div>
+
+            <div class="form-group">
+                <label class="control-label">{l s='Section Subtitle/Description' d='Modules.Mlthemebuilder.Admin'}</label>
+                <textarea name="config[subtitle_products][{$id_lang|escape:'htmlall':'UTF-8'}]" class="form-control" rows="3">{$section_data.config.subtitle_products[$id_lang]|default:''|escape:'htmlall':'UTF-8'}</textarea>
+            </div>
+
+            <div class="form-group">
+                <label class="control-label">{l s='Button Text (optional)' d='Modules.Mlthemebuilder.Admin'}</label>
+                <input type="text" name="button_text[{$id_lang|escape:'htmlall':'UTF-8'}]" class="form-control" value="{$section_data.button_texts[$id_lang]|default:''|escape:'htmlall':'UTF-8'}" placeholder="{l s='e.g., View All Products' d='Modules.Mlthemebuilder.Admin'}">
+                <p class="help-block">{l s='If set, a button will appear below the products/categories, linking to the "Button Link".' d='Modules.Mlthemebuilder.Admin'}</p>
+            </div>
+
+            <div class="form-group">
+                <label class="control-label">{l s='Button Link (optional)' d='Modules.Mlthemebuilder.Admin'}</label>
+                <input type="text" name="button_link[{$id_lang|escape:'htmlall':'UTF-8'}]" class="form-control" value="{$section_data.button_links[$id_lang]|default:'#'|escape:'htmlall':'UTF-8'}" placeholder="{$link->getPageLink('products', true)|escape:'htmlall':'UTF-8'}">
+            </div>
+        </div>
+    {/foreach}
+{if $languages|count > 1}
+    </div>
+</div>
+{/if}
+
+<hr>
+<h4>{l s='Content & Layout' d='Modules.Mlthemebuilder.Admin'}</h4>
+
+<div class="form-group">
+    <label class="control-label">{l s='Display Type' d='Modules.Mlthemebuilder.Admin'}</label>
+    <select name="config[display_type_products]" id="display_type_products" class="form-control">
+        <option value="featured" {if $section_data.config.display_type_products|default:'featured' == 'featured'}selected{/if}>{l s='Featured Products (On Sale / New)' d='Modules.Mlthemebuilder.Admin'}</option>
+        <option value="new" {if $section_data.config.display_type_products|default:'' == 'new'}selected{/if}>{l s='New Products' d='Modules.Mlthemebuilder.Admin'}</option>
+        <option value="bestsellers" {if $section_data.config.display_type_products|default:'' == 'bestsellers'}selected{/if}>{l s='Best Sellers' d='Modules.Mlthemebuilder.Admin'}</option>
+        <option value="category" {if $section_data.config.display_type_products|default:'' == 'category'}selected{/if}>{l s='Products from a Specific Category' d='Modules.Mlthemebuilder.Admin'}</option>
+        <option value="categories" {if $section_data.config.display_type_products|default:'' == 'categories'}selected{/if}>{l s='List of Categories' d='Modules.Mlthemebuilder.Admin'}</option>
+    </select>
+</div>
+
+<div id="product_options_products" class="product-type-option" {if $section_data.config.display_type_products|default:'featured' == 'categories'}style="display:none;"{/if}>
+    <div class="form-group">
+        <label class="control-label">{l s='Number of Products' d='Modules.Mlthemebuilder.Admin'}</label>
+        <input type="number" name="config[num_products]" class="form-control" value="{$section_data.config.num_products|default:8|escape:'htmlall':'UTF-8'}" min="1" max="24">
+    </div>
+</div>
+
+<div id="category_options_products" class="product-type-option" {if $section_data.config.display_type_products|default:'featured' != 'category'}style="display:none;"{/if}>
+    <div class="form-group">
+        <label class="control-label">{l s='Select Category' d='Modules.Mlthemebuilder.Admin'}</label>
+        <select name="config[id_category_products]" class="form-control">
+            {if isset($categories_for_select) && $categories_for_select}
+                {foreach from=$categories_for_select item=cat}
+                    <option value="{$cat.id_category|escape:'htmlall':'UTF-8'}" {if $section_data.config.id_category_products|default:0 == $cat.id_category}selected{/if}>
+                        {$cat.name|escape:'htmlall':'UTF-8'}
+                    </option>
+                {/foreach}
+            {else}
+                 <option value="0">{l s='No categories found' d='Modules.Mlthemebuilder.Admin'}</option>
+            {/if}
+        </select>
+    </div>
+</div>
+
+<div id="categories_list_options_products" class="product-type-option" {if $section_data.config.display_type_products|default:'featured' != 'categories'}style="display:none;"{/if}>
+    <div class="form-group">
+        <label class="control-label">{l s='Number of Columns (Categories)' d='Modules.Mlthemebuilder.Admin'}</label>
+        <select name="config[columns_categories]" class="form-control">
+            <option value="2" {if $section_data.config.columns_categories|default:3 == 2}selected{/if}>2 {l s='Columns' d='Modules.Mlthemebuilder.Admin'}</option>
+            <option value="3" {if $section_data.config.columns_categories|default:3 == 3}selected{/if}>3 {l s='Columns' d='Modules.Mlthemebuilder.Admin'}</option>
+            <option value="4" {if $section_data.config.columns_categories|default:3 == 4}selected{/if}>4 {l s='Columns' d='Modules.Mlthemebuilder.Admin'}</option>
+        </select>
+    </div>
+    <div class="form-group">
+        <label class="control-label">{l s='Show Subcategories' d='Modules.Mlthemebuilder.Admin'}</label>
+        <span class="switch prestashop-switch fixed-width-sm">
+            <input type="radio" name="config[show_subcategories_products]" id="show_subcategories_products_on" value="1" {if $section_data.config.show_subcategories_products|default:false}checked="checked"{/if}>
+            <label for="show_subcategories_products_on">{l s='Yes' d='Modules.Mlthemebuilder.Admin'}</label>
+            <input type="radio" name="config[show_subcategories_products]" id="show_subcategories_products_off" value="0" {if !$section_data.config.show_subcategories_products|default:false}checked="checked"{/if}>
+            <label for="show_subcategories_products_off">{l s='No' d='Modules.Mlthemebuilder.Admin'}</label>
+            <a class="slide-button btn"></a>
+        </span>
+    </div>
+     <div class="form-group">
+        <label class="control-label">{l s='Max Subcategories to Show' d='Modules.Mlthemebuilder.Admin'}</label>
+        <input type="number" name="config[max_subcategories_products]" class="form-control" value="{$section_data.config.max_subcategories_products|default:3|escape:'htmlall':'UTF-8'}" min="0" max="10">
+         <p class="help-block">{l s='0 for all.' d='Modules.Mlthemebuilder.Admin'}</p>
+    </div>
+</div>
+
+
+<hr>
+<h4>{l s='Appearance' d='Modules.Mlthemebuilder.Admin'}</h4>
+<div class="form-group">
+    <label class="control-label">{l s='Background Color' d='Modules.Mlthemebuilder.Admin'}</label>
+    <input type="color" name="config[background_color_products]" class="form-control color-picker" value="{$section_data.config.background_color_products|default:'#ffffff'|escape:'htmlall':'UTF-8'}">
+</div>
+<div class="form-group">
+    <label class="control-label">{l s='Product Card Style' d='Modules.Mlthemebuilder.Admin'}</label>
+    <select name="config[card_style_products]" class="form-control">
+        <option value="default" {if $section_data.config.card_style_products|default:'default' == 'default'}selected{/if}>{l s='Default (Theme defined)' d='Modules.Mlthemebuilder.Admin'}</option>
+        <option value="minimal" {if $section_data.config.card_style_products|default:'' == 'minimal'}selected{/if}>{l s='Minimal' d='Modules.Mlthemebuilder.Admin'}</option>
+        {* Add more style options if implemented *}
+    </select>
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Custom CSS Class' d='Modules.Mlthemebuilder.Admin'}</label>
+    <input type="text" name="config[custom_css_class]" class="form-control" value="{$section_data.config.custom_css_class|default:''|escape:'htmlall':'UTF-8'}">
+</div>
+
+<script type="text/javascript">
+    $(document).ready(function() {
+        function toggleProductOptions() {
+            var selectedType = $('#display_type_products').val();
+            $('.product-type-option').hide(); // Hide all options first
+            if (selectedType === 'category') {
+                $('#category_options_products').show();
+                $('#product_options_products').show(); // Number of products still relevant
+            } else if (selectedType === 'categories') {
+                $('#categories_list_options_products').show();
+            } else if (selectedType === 'featured' || selectedType === 'new' || selectedType === 'bestsellers') {
+                 $('#product_options_products').show();
+            }
+        }
+        $('#display_type_products').on('change', toggleProductOptions);
+        toggleProductOptions(); // Initial call
+
+        $('#section-modal-form-content .nav-tabs a').click(function (e) {
+            e.preventDefault();
+            $(this).tab('show');
+        });
+         $('#section-modal-form-content .nav-tabs li:first-child a').tab('show');
+    });
+</script>

--- a/modules/mlthemebuilder/views/templates/admin/sections/services.tpl
+++ b/modules/mlthemebuilder/views/templates/admin/sections/services.tpl
@@ -1,0 +1,90 @@
+{* Configuration form for Services Section *}
+<input type="hidden" name="config[type]" value="services">
+
+{* Language tabs for multilingual fields *}
+{if $languages|count > 1}
+<div class="translations tabbable">
+    <ul class="nav nav-tabs">
+        {foreach from=$languages item=language}
+            <li class="nav-item {if $language.id_lang == $current_language.id_lang}active{/if}">
+                <a href="#services_lang_{$language.id_lang|escape:'htmlall':'UTF-8'}" class="nav-link" data-toggle="tab">{$language.name|escape:'htmlall':'UTF-8'}</a>
+            </li>
+        {/foreach}
+    </ul>
+    <div class="tab-content">
+{/if}
+    {foreach from=$languages item=language}
+        {assign var=id_lang value=$language.id_lang}
+        <div class="tab-pane {if $id_lang == $current_language.id_lang}active{/if}" id="services_lang_{$id_lang|escape:'htmlall':'UTF-8'}">
+            <div class="form-group">
+                <label class="control-label">{l s='Section Title' d='Modules.Mlthemebuilder.Admin'}</label>
+                <input type="text" name="title[{$id_lang|escape:'htmlall':'UTF-8'}]" class="form-control" value="{$section_data.titles[$id_lang]|default:''|escape:'htmlall':'UTF-8'}" placeholder="{l s='e.g., Our Services' d='Modules.Mlthemebuilder.Admin'}">
+            </div>
+
+            <div class="form-group">
+                <label class="control-label">{l s='Section Subtitle/Description' d='Modules.Mlthemebuilder.Admin'}</label>
+                <textarea name="config[subtitle_services][{$id_lang|escape:'htmlall':'UTF-8'}]" class="form-control" rows="3">{$section_data.config.subtitle_services[$id_lang]|default:''|escape:'htmlall':'UTF-8'}</textarea>
+                <p class="help-block">{l s='Optional text displayed below the section title.' d='Modules.Mlthemebuilder.Admin'}</p>
+            </div>
+        </div>
+    {/foreach}
+{if $languages|count > 1}
+    </div>
+</div>
+{/if}
+
+<hr>
+<h4>{l s='Layout & Content' d='Modules.Mlthemebuilder.Admin'}</h4>
+
+<div class="form-group">
+    <label class="control-label">{l s='Number of Columns' d='Modules.Mlthemebuilder.Admin'}</label>
+    <select name="config[columns_services]" class="form-control">
+        <option value="2" {if $section_data.config.columns_services|default:3 == 2}selected{/if}>2 {l s='Columns' d='Modules.Mlthemebuilder.Admin'}</option>
+        <option value="3" {if $section_data.config.columns_services|default:3 == 3}selected{/if}>3 {l s='Columns' d='Modules.Mlthemebuilder.Admin'}</option>
+        <option value="4" {if $section_data.config.columns_services|default:3 == 4}selected{/if}>4 {l s='Columns' d='Modules.Mlthemebuilder.Admin'}</option>
+    </select>
+    <p class="help-block">{l s='How many services to display per row.' d='Modules.Mlthemebuilder.Admin'}</p>
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Maximum Services to Display' d='Modules.Mlthemebuilder.Admin'}</label>
+    <input type="number" name="config[max_services]" class="form-control" value="{$section_data.config.max_services|default:6|escape:'htmlall':'UTF-8'}" min="1" max="20">
+    <p class="help-block">{l s='Total number of services to show in this section. Leave empty or 0 for all active services.' d='Modules.Mlthemebuilder.Admin'}</p>
+</div>
+
+<div class="alert alert-info">
+    <i class="icon-info-sign"></i>
+    {l s='Services (icons, titles, descriptions) are managed globally under the "Manage Services" tab in the module configuration.' d='Modules.Mlthemebuilder.Admin'}
+    {l s='This section will display active services based on their order.' d='Modules.Mlthemebuilder.Admin'}
+</div>
+
+
+<hr>
+<h4>{l s='Appearance' d='Modules.Mlthemebuilder.Admin'}</h4>
+<div class="form-group">
+    <label class="control-label">{l s='Background Color' d='Modules.Mlthemebuilder.Admin'}</label>
+    <input type="color" name="config[background_color_services]" class="form-control color-picker" value="{$section_data.config.background_color_services|default:'#f8f9fa'|escape:'htmlall':'UTF-8'}">
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Service Card Style' d='Modules.Mlthemebuilder.Admin'}</label>
+    <select name="config[card_style_services]" class="form-control">
+        <option value="default" {if $section_data.config.card_style_services|default:'default' == 'default'}selected{/if}>{l s='Default (icon top, text below)' d='Modules.Mlthemebuilder.Admin'}</option>
+        <option value="icon_left" {if $section_data.config.card_style_services|default:'' == 'icon_left'}selected{/if}>{l s='Icon Left, Text Right' d='Modules.Mlthemebuilder.Admin'}</option>
+        {* Add more style options if implemented in CSS/front.tpl *}
+    </select>
+</div>
+
+<div class="form-group">
+    <label class="control-label">{l s='Custom CSS Class' d='Modules.Mlthemebuilder.Admin'}</label>
+    <input type="text" name="config[custom_css_class]" class="form-control" value="{$section_data.config.custom_css_class|default:''|escape:'htmlall':'UTF-8'}" placeholder="{l s='e.g., my-custom-services-style' d='Modules.Mlthemebuilder.Admin'}">
+</div>
+
+{* Initialize Bootstrap tabs if they are part of the loaded form *}
+<script type="text/javascript">
+    $('#section-modal-form-content .nav-tabs a').click(function (e) {
+        e.preventDefault();
+        $(this).tab('show');
+    });
+    $('#section-modal-form-content .nav-tabs li:first-child a').tab('show');
+</script>

--- a/modules/mlthemebuilder/views/templates/hook/_partials/index.php
+++ b/modules/mlthemebuilder/views/templates/hook/_partials/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../'); // Redirect to modules/mlthemebuilder/views/templates/hook/
+exit;

--- a/modules/mlthemebuilder/views/templates/hook/_partials/product_grid.tpl
+++ b/modules/mlthemebuilder/views/templates/hook/_partials/product_grid.tpl
@@ -1,0 +1,154 @@
+{* Partial template for displaying a grid of products *}
+{* Expects an array $products, where each product is an object/array from Product Presenter *}
+
+{if isset($products) && $products|count > 0}
+    <div class="row product_list grid"> {* Assuming Bootstrap grid, adjust if using custom grid *}
+        {foreach from=$products item="product_item_data" name=productloop}
+            <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3"> {* Adjust column classes as needed *}
+                <article class="product-miniature js-product-miniature" data-id-product="{$product_item_data.id_product|escape:'htmlall':'UTF-8'}" data-id-product-attribute="{$product_item_data.id_product_attribute|escape:'htmlall':'UTF-8'}">
+                    <div class="thumbnail-container">
+                        <a href="{$product_item_data.url|escape:'htmlall':'UTF-8'}" class="thumbnail product-thumbnail">
+                            <img
+                                src="{$product_item_data.cover.bySize.home_default.url|escape:'htmlall':'UTF-8'}"
+                                alt="{$product_item_data.cover.legend|escape:'htmlall':'UTF-8'}"
+                                data-full-size-image-url="{$product_item_data.cover.large.url|escape:'htmlall':'UTF-8'}"
+                                class="lazyload"
+                                loading="lazy"
+                                width="{$product_item_data.cover.bySize.home_default.width|escape:'htmlall':'UTF-8'}"
+                                height="{$product_item_data.cover.bySize.home_default.height|escape:'htmlall':'UTF-8'}"
+                            >
+                        </a>
+
+                        {if $product_item_data.show_price}
+                            {if $product_item_data.has_discount}
+                                <ul class="product-flags">
+                                    {foreach from=$product_item_data.flags item=flag}
+                                        <li class="product-flag {$flag.type|escape:'htmlall':'UTF-8'}">{$flag.label|escape:'htmlall':'UTF-8'}</li>
+                                    {/foreach}
+                                </ul>
+                            {/if}
+                        {/if}
+                    </div>
+
+                    <div class="product-description">
+                        <h5 class="h3 product-title" itemprop="name"><a href="{$product_item_data.url|escape:'htmlall':'UTF-8'}">{$product_item_data.name|truncate:30:'...'|escape:'htmlall':'UTF-8'}</a></h5>
+
+                        {if $product_item_data.show_price}
+                            <div class="product-price-and-shipping">
+                                {if $product_item_data.has_discount}
+                                    {hook h='displayProductPriceBlock' product=$product_item_data type="old_price"}
+                                    <span class="regular-price">{$product_item_data.regular_price|escape:'htmlall':'UTF-8'}</span>
+                                {/if}
+
+                                {hook h='displayProductPriceBlock' product=$product_item_data type="before_price"}
+                                <span class="price">{$product_item_data.price|escape:'htmlall':'UTF-8'}</span>
+                                {hook h='displayProductPriceBlock' product=$product_item_data type='unit_price'}
+                                {hook h='displayProductPriceBlock' product=$product_item_data type='weight'}
+                            </div>
+                        {/if}
+                    </div>
+
+                    {* Quick view, add to cart, etc. can be added here if needed, similar to PrestaShop's product-miniature.tpl *}
+                    {* Example for Add to Cart (simplified) *}
+                    {if $product_item_data.add_to_cart_url}
+                        <div class="product-add-to-cart text-center">
+                            <form action="{$urls.pages.cart|escape:'htmlall':'UTF-8'}" method="post">
+                                <input type="hidden" name="token" value="{$static_token|escape:'htmlall':'UTF-8'}">
+                                <input type="hidden" name="id_product" value="{$product_item_data.id_product|escape:'htmlall':'UTF-8'}">
+                                <input type="number" name="qty" value="1" min="1" style="display:none;">
+                                <button class="btn btn-primary add-to-cart-btn" data-button-action="add-to-cart" type="submit" {if !$product_item_data.available_for_order || $product_item_data.quantity <= 0}disabled{/if}>
+                                    <i class="material-icons">shopping_cart</i> {l s='Add to cart' d='Shop.Theme.Actions'}
+                                </button>
+                            </form>
+                        </div>
+                    {/if}
+
+                </article>
+            </div>
+        {/foreach}
+    </div>
+{else}
+    <p class="alert alert-info">{l s='No products found for this selection.' d='Modules.Mlthemebuilder.Shop'}</p>
+{/if}
+
+<style type="text/css">
+/* Basic styling for product grid items - can be expanded in front.css */
+.product_list.grid .product-miniature {
+    border: 1px solid #e0e0e0;
+    border-radius: var(--ml-border-radius-cards, 8px);
+    padding: 15px;
+    margin-bottom: 20px;
+    text-align: center;
+    background-color: #fff;
+    transition: box-shadow 0.3s ease;
+}
+.product_list.grid .product-miniature:hover {
+    box-shadow: var(--ml-shadow, 0 5px 15px rgba(0,0,0,0.1));
+}
+.product_list.grid .thumbnail-container {
+    margin-bottom: 10px;
+    position: relative; /* For flags */
+}
+.product_list.grid .product-thumbnail img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 4px;
+}
+.product_list.grid .product-title {
+    font-size: calc(var(--ml-base-font-size, 16px) * 1.1);
+    font-weight: 600;
+    margin-bottom: 8px;
+    min-height: 2.4em; /* Ensure consistent height for titles */
+}
+.product_list.grid .product-title a {
+    color: var(--ml-text-color, #333);
+    text-decoration: none;
+}
+.product_list.grid .product-title a:hover {
+    color: var(--ml-link-color, var(--ml-primary-color, #667eea));
+}
+.product_list.grid .product-price-and-shipping .price {
+    font-weight: bold;
+    color: var(--ml-primary-color, #667eea);
+    font-size: calc(var(--ml-base-font-size, 16px) * 1.2);
+}
+.product_list.grid .regular-price {
+    text-decoration: line-through;
+    color: #999;
+    font-size: calc(var(--ml-base-font-size, 16px) * 0.9);
+    margin-right: 5px;
+}
+.product_list.grid .product-flags {
+    position: absolute;
+    top: 5px;
+    left: 5px;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    z-index: 1;
+}
+.product_list.grid .product-flag {
+    background-color: var(--ml-secondary-color, #ff6b6b);
+    color: white;
+    padding: 3px 8px;
+    font-size: 0.8em;
+    border-radius: 3px;
+    margin-bottom: 3px;
+    display: inline-block;
+}
+.product_list.grid .product-flag.on-sale { background-color: #28a745; } /* Green for sale */
+.product_list.grid .product-flag.new { background-color: #17a2b8; } /* Blue for new */
+
+.product_list.grid .product-add-to-cart {
+    margin-top: 15px;
+}
+.product_list.grid .add-to-cart-btn {
+    font-size: 0.9em;
+    padding: 8px 15px;
+}
+.product_list.grid .add-to-cart-btn .material-icons {
+    font-size: 1.2em;
+    vertical-align: middle;
+    margin-right: 5px;
+}
+</style>

--- a/modules/mlthemebuilder/views/templates/hook/footer.tpl
+++ b/modules/mlthemebuilder/views/templates/hook/footer.tpl
@@ -1,0 +1,31 @@
+{* MlThemeBuilder - Hook Footer Template *}
+
+{* This template can be used to output custom JS from settings before the closing </body> tag *}
+
+{if isset($mltheme_custom_js_footer) && $mltheme_custom_js_footer}
+    <script type="text/javascript" id="mltheme-custom-js-footer">
+        //<![CDATA[
+        {$mltheme_custom_js_footer nofilter} {* Use with caution, ensure sanitization on input if possible, or trust admin input *}
+        //]]>
+    </script>
+{/if}
+
+{* Example: Add a scroll-to-top button if enabled in settings (or handle in front.js) *}
+{* {if MlThemeSetting::getSettingValue('enable_scroll_to_top')}
+    <a href="#" class="ml-scroll-to-top" title="{l s='Scroll to top' d='Modules.Mlthemebuilder.Shop'}">
+        <i class="material-icons">keyboard_arrow_up</i>
+    </a>
+{/if} *}
+
+{* Schema.org markup or other structured data can also be added here if relevant to the module's global functionality *}
+{*
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "{$shop.name|escape:'htmlall':'UTF-8'}",
+  "url": "{$urls.base_url|escape:'htmlall':'UTF-8'}"
+  {if $shop.logo}, "logo": "{$shop.logo|escape:'htmlall':'UTF-8'}"{/if}
+}
+</script>
+*}

--- a/modules/mlthemebuilder/views/templates/hook/header.tpl
+++ b/modules/mlthemebuilder/views/templates/hook/header.tpl
@@ -1,0 +1,103 @@
+{* MlThemeBuilder - Hook Header Template *}
+
+{* This template can be used to output global styles, custom CSS/JS from settings, etc., directly into the <head> *}
+
+{if isset($mltheme_global_styles) && $mltheme_global_styles}
+    <style type="text/css" id="mltheme-global-styles">
+        :root {
+            {if isset($mltheme_global_styles.primary_color) && $mltheme_global_styles.primary_color}
+                --ml-primary-color: {$mltheme_global_styles.primary_color|escape:'htmlall':'UTF-8'};
+                /* Basic RGB conversion for opacity usage, JS might be better for complex cases */
+                {$rgb_primary = $mltheme_global_styles.primary_color|replace:'#':'' }
+                {if $rgb_primary|strlen == 6}
+                    --ml-primary-color-rgb: {hexdec(substr($rgb_primary, 0, 2))}, {hexdec(substr($rgb_primary, 2, 2))}, {hexdec(substr($rgb_primary, 4, 2))};
+                {elseif $rgb_primary|strlen == 3}
+                     --ml-primary-color-rgb: {hexdec(substr($rgb_primary, 0, 1)|str_repeat:2)}, {hexdec(substr($rgb_primary, 1, 1)|str_repeat:2)}, {hexdec(substr($rgb_primary, 2, 1)|str_repeat:2)};
+                {/if}
+            {/if}
+            {if isset($mltheme_global_styles.secondary_color) && $mltheme_global_styles.secondary_color}
+                --ml-secondary-color: {$mltheme_global_styles.secondary_color|escape:'htmlall':'UTF-8'};
+            {/if}
+            {if isset($mltheme_global_styles.text_color) && $mltheme_global_styles.text_color}
+                --ml-text-color: {$mltheme_global_styles.text_color|escape:'htmlall':'UTF-8'};
+            {/if}
+            {if isset($mltheme_global_styles.link_color) && $mltheme_global_styles.link_color}
+                --ml-link-color: {$mltheme_global_styles.link_color|escape:'htmlall':'UTF-8'};
+            {else if isset($mltheme_global_styles.primary_color) && $mltheme_global_styles.primary_color}
+                --ml-link-color: var(--ml-primary-color);
+            {/if}
+            {if isset($mltheme_global_styles.bg_light_color) && $mltheme_global_styles.bg_light_color}
+                --ml-bg-light-color: {$mltheme_global_styles.bg_light_color|escape:'htmlall':'UTF-8'};
+            {/if}
+            {if isset($mltheme_global_styles.bg_dark_color) && $mltheme_global_styles.bg_dark_color}
+                --ml-bg-dark-color: {$mltheme_global_styles.bg_dark_color|escape:'htmlall':'UTF-8'};
+            {/if}
+            {if isset($mltheme_global_styles.primary_font) && $mltheme_global_styles.primary_font}
+                --ml-font-primary: {$mltheme_global_styles.primary_font|escape:'htmlall':'UTF-8'};
+            {/if}
+            {if isset($mltheme_global_styles.secondary_font) && $mltheme_global_styles.secondary_font}
+                --ml-font-secondary: {$mltheme_global_styles.secondary_font|escape:'htmlall':'UTF-8'};
+            {else if isset($mltheme_global_styles.primary_font) && $mltheme_global_styles.primary_font}
+                 --ml-font-secondary: var(--ml-font-primary);
+            {/if}
+            {if isset($mltheme_global_styles.base_font_size) && $mltheme_global_styles.base_font_size}
+                --ml-base-font-size: {$mltheme_global_styles.base_font_size|intval}px;
+            {/if}
+            {if isset($mltheme_global_styles.heading_font_scale) && $mltheme_global_styles.heading_font_scale}
+                --ml-heading-font-scale: {$mltheme_global_styles.heading_font_scale|floatval};
+            {/if}
+            {if isset($mltheme_global_styles.container_max_width) && $mltheme_global_styles.container_max_width}
+                --ml-container-max-width: {$mltheme_global_styles.container_max_width|intval}px;
+            {/if}
+            {if isset($mltheme_global_styles.section_padding_y) && $mltheme_global_styles.section_padding_y}
+                --ml-section-padding-y: {$mltheme_global_styles.section_padding_y|intval}px;
+            {/if}
+            {if isset($mltheme_global_styles.button_border_radius) && $mltheme_global_styles.button_border_radius}
+                --ml-button-border-radius: {$mltheme_global_styles.button_border_radius|intval}px;
+            {/if}
+        }
+        body a { color: var(--ml-link-color); }
+        /* Add more global styles here if needed, using the CSS variables */
+    </style>
+{/if}
+
+{if isset($mltheme_custom_css) && $mltheme_custom_css}
+    <style type="text/css" id="mltheme-custom-css">
+        {$mltheme_custom_css nofilter} {* Use with caution, ensure sanitization on input if possible, or trust admin input *}
+    </style>
+{/if}
+
+{if isset($mltheme_custom_js_header) && $mltheme_custom_js_header}
+    <script type="text/javascript" id="mltheme-custom-js-header">
+        //<![CDATA[
+        {$mltheme_custom_js_header nofilter} {* Use with caution, ensure sanitization on input if possible, or trust admin input *}
+        //]]>
+    </script>
+{/if}
+
+{* Preload critical fonts if specified and not handled by Google Fonts link *}
+{* Example: <link rel="preload" href="{$path_to_font_file}" as="font" type="font/woff2" crossorigin> *}
+
+{* Add JS variables for frontend scripts, like AJAX URLs or translations if prestashop object is not fully populated *}
+<script type="text/javascript">
+    if (typeof window.prestashop === 'undefined') {
+        window.prestashop = {};
+    }
+    if (typeof window.prestashop.modules === 'undefined') {
+        window.prestashop.modules = {};
+    }
+    if (typeof window.prestashop.modules.mlthemebuilder === 'undefined') {
+        window.prestashop.modules.mlthemebuilder = {};
+    }
+    // This should ideally match the AdminController's AJAX link generation
+    window.prestashop.modules.mlthemebuilder.ajaxUrl = '{$link->getModuleLink("mlthemebuilder", "ajax", [], true)|escape:'htmlall':'UTF-8'}';
+
+    // Frontend translations for JS (example)
+    window.prestashop.modules.mlthemebuilder.translations = {
+        sending: "{l s='Sending...' d='Modules.Mlthemebuilder.Shop' js=1}",
+        messageSent: "{l s='Message sent successfully!' d='Modules.Mlthemebuilder.Shop' js=1}",
+        errorSendingMessage: "{l s='An error occurred. Please try again.' d='Modules.Mlthemebuilder.Shop' js=1}",
+        fillRequiredFields: "{l s='Please fill all required fields.' d='Modules.Mlthemebuilder.Shop' js=1}"
+        // Add more as needed
+    };
+</script>

--- a/modules/mlthemebuilder/views/templates/hook/index.php
+++ b/modules/mlthemebuilder/views/templates/hook/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../'); // Redirect to modules/mlthemebuilder/views/templates/
+exit;

--- a/modules/mlthemebuilder/views/templates/hook/sections/banner.tpl
+++ b/modules/mlthemebuilder/views/templates/hook/sections/banner.tpl
@@ -1,0 +1,33 @@
+<!-- Banner CTA Section Template -->
+<section class="banner-cta-section" id="banner-{$section.section_id|escape:'htmlall':'UTF-8'}" style="{if isset($section.config.background_color_banner) && $section.config.background_color_banner}background-color: {$section.config.background_color_banner|escape:'htmlall':'UTF-8'};{/if} {if isset($section.config.background_image_banner) && $section.config.background_image_banner}background-image: url('{$img_dir_theme|escape:'htmlall':'UTF-8'}sections/{$section.config.background_image_banner|escape:'htmlall':'UTF-8'}');{/if}">
+    <div class="banner-container container">
+        <div class="banner-content {if isset($section.config.layout_banner) && $section.config.layout_banner == 'image_left'}image-left{else}image-right{/if}">
+            <div class="banner-text">
+                {if isset($section.title) && $section.title}
+                    <h2 class="banner-title">{$section.title|escape:'htmlall':'UTF-8'}</h2>
+                {elseif isset($section.banner_title) && $section.banner_title}
+                     <h2 class="banner-title">{$section.banner_title|escape:'htmlall':'UTF-8'}</h2>
+                {/if}
+
+                {if isset($section.content) && $section.content}
+                    <p class="banner-description">{$section.content nofilter}</p> {* Allow HTML, sanitize on input *}
+                {elseif isset($section.banner_text) && $section.banner_text}
+                    <p class="banner-description">{$section.banner_text nofilter}</p>
+                {/if}
+
+                {if (isset($section.button_text) && $section.button_text) || (isset($section.banner_button_text) && $section.banner_button_text)}
+                <a href="{if isset($section.button_link) && $section.button_link}{$section.button_link|escape:'htmlall':'UTF-8'}{elseif isset($section.banner_button_link) && $section.banner_button_link}{$section.banner_button_link|escape:'htmlall':'UTF-8'}{else}#{/if}" class="btn btn-secondary banner-btn">
+                    {if isset($section.button_text) && $section.button_text}{$section.button_text|escape:'htmlall':'UTF-8'}{elseif isset($section.banner_button_text) && $section.banner_button_text}{$section.banner_button_text|escape:'htmlall':'UTF-8'}{/if}
+                </a>
+                {/if}
+            </div>
+            <div class="banner-image">
+                {if isset($section.config.image_banner) && $section.config.image_banner}
+                    <img src="{$img_dir_theme|escape:'htmlall':'UTF-8'}sections/{$section.config.image_banner|escape:'htmlall':'UTF-8'}" alt="{if isset($section.title)}{$section.title|escape:'htmlall':'UTF-8'}{elseif isset($section.banner_title)}{$section.banner_title|escape:'htmlall':'UTF-8'}{/if}" class="banner-img lazyload">
+                {elseif isset($section.banner_image) && $section.banner_image}
+                     <img src="{$section.banner_image|escape:'htmlall':'UTF-8'}" alt="{if isset($section.title)}{$section.title|escape:'htmlall':'UTF-8'}{elseif isset($section.banner_title)}{$section.banner_title|escape:'htmlall':'UTF-8'}{/if}" class="banner-img lazyload">
+                {/if}
+            </div>
+        </div>
+    </div>
+</section>

--- a/modules/mlthemebuilder/views/templates/hook/sections/brands.tpl
+++ b/modules/mlthemebuilder/views/templates/hook/sections/brands.tpl
@@ -1,0 +1,58 @@
+<!-- Brands Section Template -->
+<section class="brands-section" id="brands-{$section.section_id|escape:'htmlall':'UTF-8'}">
+    <div class="container">
+        <div class="section-header">
+            {if isset($section.title) && $section.title}
+                <h2 class="section-title">{$section.title|escape:'htmlall':'UTF-8'}</h2>
+            {elseif isset($section.brands_list_title) && $section.brands_list_title}
+                 <h2 class="section-title">{$section.brands_list_title|escape:'htmlall':'UTF-8'}</h2>
+            {else}
+                <h2 class="section-title">{l s='Brands We Trust' d='Modules.Customthemebuilder.Shop'}</h2>
+            {/if}
+        </div>
+
+        {if isset($section.brands_list) && $section.brands_list}
+            <div class="brands-slider" data-duration="{$section.config.speed_brands|default:30|escape:'htmlall':'UTF-8'}s">
+                <div class="brands-track">
+                    {foreach from=$section.brands_list item=brand_item}
+                        <div class="brand-item">
+                            {if isset($brand_item.url) && $brand_item.url}
+                                <a href="{$brand_item.url|escape:'htmlall':'UTF-8'}" target="_blank" rel="noopener noreferrer">
+                            {/if}
+
+                            {if isset($brand_item.logo) && $brand_item.logo}
+                                <img src="{$img_dir_theme|escape:'htmlall':'UTF-8'}brands/{$brand_item.logo|escape:'htmlall':'UTF-8'}" alt="{$brand_item.name|escape:'htmlall':'UTF-8'}" class="brand-logo lazyload" loading="lazy">
+                            {else}
+                                <span class="brand-name">{$brand_item.name|escape:'htmlall':'UTF-8'}</span>
+                            {/if}
+
+                            {if isset($brand_item.url) && $brand_item.url}
+                                </a>
+                            {/if}
+                        </div>
+                    {/foreach}
+                    {* Duplicate for infinite scroll effect, handled by JS if more robust solution is needed *}
+                     {foreach from=$section.brands_list item=brand_item}
+                        <div class="brand-item">
+                            {if isset($brand_item.url) && $brand_item.url}
+                                <a href="{$brand_item.url|escape:'htmlall':'UTF-8'}" target="_blank" rel="noopener noreferrer">
+                            {/if}
+
+                            {if isset($brand_item.logo) && $brand_item.logo}
+                                <img src="{$img_dir_theme|escape:'htmlall':'UTF-8'}brands/{$brand_item.logo|escape:'htmlall':'UTF-8'}" alt="{$brand_item.name|escape:'htmlall':'UTF-8'}" class="brand-logo lazyload" loading="lazy">
+                            {else}
+                                <span class="brand-name">{$brand_item.name|escape:'htmlall':'UTF-8'}</span>
+                            {/if}
+
+                            {if isset($brand_item.url) && $brand_item.url}
+                                </a>
+                            {/if}
+                        </div>
+                    {/foreach}
+                </div>
+            </div>
+        {else}
+            <p class="text-center">{l s='No brands to display at the moment.' d='Modules.Customthemebuilder.Shop'}</p>
+        {/if}
+    </div>
+</section>

--- a/modules/mlthemebuilder/views/templates/hook/sections/hero.tpl
+++ b/modules/mlthemebuilder/views/templates/hook/sections/hero.tpl
@@ -1,0 +1,35 @@
+<!-- Hero Section Template -->
+<section class="hero-section" id="hero-{$section.section_id|escape:'htmlall':'UTF-8'}" style="{if isset($section.config.background_color) && $section.config.background_color}background-color: {$section.config.background_color|escape:'htmlall':'UTF-8'};{/if}">
+    <div class="hero-container container">
+        <div class="hero-content">
+            <div class="hero-text">
+                {if isset($section.title) && $section.title}
+                    <h1 class="hero-title">{$section.title|escape:'htmlall':'UTF-8'}</h1>
+                {elseif isset($section.hero_title) && $section.hero_title}
+                     <h1 class="hero-title">{$section.hero_title|escape:'htmlall':'UTF-8'}</h1>
+                {/if}
+
+                {if isset($section.config.subtitle_hero[$language.id_lang]) && $section.config.subtitle_hero[$language.id_lang]}
+                    <p class="hero-subtitle">{$section.config.subtitle_hero[$language.id_lang]|escape:'htmlall':'UTF-8'}</p>
+                {elseif isset($section.hero_subtitle) && $section.hero_subtitle}
+                     <p class="hero-subtitle">{$section.hero_subtitle|escape:'htmlall':'UTF-8'}</p>
+                {/if}
+
+                {if (isset($section.button_text) && $section.button_text) || (isset($section.hero_button_text) && $section.hero_button_text)}
+                <div class="hero-buttons">
+                    <a href="{if isset($section.button_link) && $section.button_link}{$section.button_link|escape:'htmlall':'UTF-8'}{elseif isset($section.hero_button_link) && $section.hero_button_link}{$section.hero_button_link|escape:'htmlall':'UTF-8'}{else}#{/if}" class="btn btn-primary hero-btn">
+                        {if isset($section.button_text) && $section.button_text}{$section.button_text|escape:'htmlall':'UTF-8'}{elseif isset($section.hero_button_text) && $section.hero_button_text}{$section.hero_button_text|escape:'htmlall':'UTF-8'}{/if}
+                    </a>
+                </div>
+                {/if}
+            </div>
+            <div class="hero-image">
+                {if isset($section.config.image_hero) && $section.config.image_hero}
+                    <img src="{$img_dir_theme|escape:'htmlall':'UTF-8'}sections/{$section.config.image_hero|escape:'htmlall':'UTF-8'}" alt="{if isset($section.title)}{$section.title|escape:'htmlall':'UTF-8'}{elseif isset($section.hero_title)}{$section.hero_title|escape:'htmlall':'UTF-8'}{/if}" class="hero-img lazyload">
+                {elseif isset($section.hero_image) && $section.hero_image}
+                     <img src="{$section.hero_image|escape:'htmlall':'UTF-8'}" alt="{if isset($section.title)}{$section.title|escape:'htmlall':'UTF-8'}{elseif isset($section.hero_title)}{$section.hero_title|escape:'htmlall':'UTF-8'}{/if}" class="hero-img lazyload">
+                {/if}
+            </div>
+        </div>
+    </div>
+</section>

--- a/modules/mlthemebuilder/views/templates/hook/sections/index.php
+++ b/modules/mlthemebuilder/views/templates/hook/sections/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../'); // Redirect to modules/mlthemebuilder/views/templates/hook/
+exit;

--- a/modules/mlthemebuilder/views/templates/hook/sections/products.tpl
+++ b/modules/mlthemebuilder/views/templates/hook/sections/products.tpl
@@ -1,0 +1,74 @@
+<!-- Products Section Template -->
+<section class="products-section" id="products-{$section.section_id|escape:'htmlall':'UTF-8'}">
+    <div class="container">
+        <div class="section-header">
+            {if isset($section.title) && $section.title}
+                <h2 class="section-title">{$section.title|escape:'htmlall':'UTF-8'}</h2>
+            {elseif isset($section.products_list_title) && $section.products_list_title}
+                 <h2 class="section-title">{$section.products_list_title|escape:'htmlall':'UTF-8'}</h2>
+            {else}
+                <h2 class="section-title">{l s='Our Products' d='Modules.Customthemebuilder.Shop'}</h2>
+            {/if}
+
+            {if isset($section.content) && $section.content}
+                <p class="section-subtitle">{$section.content|escape:'htmlall':'UTF-8'}</p>
+            {else}
+                 <p class="section-subtitle">{l s='Explore our categories or featured products' d='Modules.Customthemebuilder.Shop'}</p>
+            {/if}
+        </div>
+
+        {* Option to display categories or products based on config *}
+        {if isset($section.config.display_type_products) && $section.config.display_type_products == 'categories' && isset($section.categories_list) && $section.categories_list}
+            <div class="categories-grid columns-{$section.config.columns_categories|default:3|escape:'htmlall':'UTF-8'}">
+                {foreach from=$section.categories_list item=category_item}
+                    {if $category_item.active}
+                    <div class="category-card">
+                        <div class="category-image">
+                            {assign var=categoryImage value=$link->getCatImageLink($category_item.link_rewrite, $category_item.id_category, 'category_default')}
+                            <a href="{$link->getCategoryLink($category_item.id_category, $category_item.link_rewrite)|escape:'htmlall':'UTF-8'}">
+                                <img src="{$categoryImage|escape:'htmlall':'UTF-8'}" alt="{$category_item.name|escape:'htmlall':'UTF-8'}" class="category-img lazyload" loading="lazy">
+                            </a>
+                        </div>
+                        <div class="category-content">
+                            <h3 class="category-title">
+                                <a href="{$link->getCategoryLink($category_item.id_category, $category_item.link_rewrite)|escape:'htmlall':'UTF-8'}">
+                                    {$category_item.name|escape:'htmlall':'UTF-8'}
+                                </a>
+                            </h3>
+
+                            {if isset($section.config.show_subcategories_products) && $section.config.show_subcategories_products && isset($category_item.children) && $category_item.children}
+                                <div class="subcategories">
+                                    {foreach from=$category_item.children item=subcategory_item name=subcatloop}
+                                        {if $smarty.foreach.subcatloop.iteration <= ($section.config.max_subcategories_products|default:3)}
+                                        <a href="{$link->getCategoryLink($subcategory_item.id_category, $subcategory_item.link_rewrite)|escape:'htmlall':'UTF-8'}" class="subcategory-link">
+                                            {$subcategory_item.name|escape:'htmlall':'UTF-8'}
+                                        </a>
+                                        {/if}
+                                    {/foreach}
+                                </div>
+                            {/if}
+                            <a href="{$link->getCategoryLink($category_item.id_category, $category_item.link_rewrite)|escape:'htmlall':'UTF-8'}" class="btn btn-outline category-btn">
+                                {l s='View Category' d='Modules.Customthemebuilder.Shop'}
+                            </a>
+                        </div>
+                    </div>
+                    {/if}
+                {/foreach}
+            </div>
+        {elseif isset($section.products_list) && $section.products_list}
+            {* Display products in a grid - This requires product_item.tpl or similar *}
+            <div class="products-grid">
+                {include file='module:customthemebuilder/views/templates/hook/_partials/product_grid.tpl' products=$section.products_list}
+            </div>
+             {if isset($section.button_text) && $section.button_text && isset($section.button_link) && $section.button_link}
+                <div class="text-center section-footer-link">
+                    <a href="{$section.button_link|escape:'htmlall':'UTF-8'}" class="btn btn-primary">
+                        {$section.button_text|escape:'htmlall':'UTF-8'}
+                    </a>
+                </div>
+            {/if}
+        {else}
+            <p class="text-center">{l s='No products or categories to display at the moment.' d='Modules.Customthemebuilder.Shop'}</p>
+        {/if}
+    </div>
+</section>

--- a/modules/mlthemebuilder/views/templates/hook/sections/services.tpl
+++ b/modules/mlthemebuilder/views/templates/hook/sections/services.tpl
@@ -1,0 +1,48 @@
+<!-- Services Section Template -->
+<section class="services-section" id="services-{$section.section_id|escape:'htmlall':'UTF-8'}">
+    <div class="container">
+        <div class="section-header">
+            {if isset($section.title) && $section.title}
+                <h2 class="section-title">{$section.title|escape:'htmlall':'UTF-8'}</h2>
+            {elseif isset($section.config.title_services[$language.id_lang]) && $section.config.title_services[$language.id_lang]}
+                <h2 class="section-title">{$section.config.title_services[$language.id_lang]|escape:'htmlall':'UTF-8'}</h2>
+            {else}
+                <h2 class="section-title">{l s='Our Services' d='Modules.Customthemebuilder.Shop'}</h2>
+            {/if}
+
+            {if isset($section.content) && $section.content}
+                 <p class="section-subtitle">{$section.content|escape:'htmlall':'UTF-8'}</p>
+            {elseif isset($section.config.subtitle_services[$language.id_lang]) && $section.config.subtitle_services[$language.id_lang]}
+                <p class="section-subtitle">{$section.config.subtitle_services[$language.id_lang]|escape:'htmlall':'UTF-8'}</p>
+            {else}
+                <p class="section-subtitle">{l s='Discover what we can do for you' d='Modules.Customthemebuilder.Shop'}</p>
+            {/if}
+        </div>
+
+        {if isset($section.services_list) && $section.services_list}
+            <div class="services-grid columns-{$section.config.columns_services|default:3|escape:'htmlall':'UTF-8'}">
+                {foreach from=$section.services_list item=service_item}
+                    <div class="service-card">
+                        {if isset($service_item.icon) && $service_item.icon}
+                            <div class="service-icon">
+                                {if $service_item.icon|startsWith:'fa-' || $service_item.icon|startsWith:'fas ' || $service_item.icon|startsWith:'far ' || $service_item.icon|startsWith:'fab '}
+                                    <i class="{$service_item.icon|escape:'htmlall':'UTF-8'}"></i>
+                                {else}
+                                    <img src="{$img_dir_theme|escape:'htmlall':'UTF-8'}icons/{$service_item.icon|escape:'htmlall':'UTF-8'}" alt="{$service_item.title|escape:'htmlall':'UTF-8'}" class="service-icon-img lazyload">
+                                {/if}
+                            </div>
+                        {/if}
+                        {if isset($service_item.title) && $service_item.title}
+                            <h3 class="service-title">{$service_item.title|escape:'htmlall':'UTF-8'}</h3>
+                        {/if}
+                        {if isset($service_item.description) && $service_item.description}
+                            <div class="service-description">{$service_item.description nofilter}</div> {* Allow HTML for description, ensure it's sanitized on input *}
+                        {/if}
+                    </div>
+                {/foreach}
+            </div>
+        {else}
+            <p class="text-center">{l s='No services available at the moment.' d='Modules.Customthemebuilder.Shop'}</p>
+        {/if}
+    </div>
+</section>

--- a/modules/mlthemebuilder/views/templates/index.php
+++ b/modules/mlthemebuilder/views/templates/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2023 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2023 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../'); // Redirect to modules/mlthemebuilder/views/
+exit;


### PR DESCRIPTION
Establishes the complete directory structure for the MlThemeBuilder module. Includes renamed and updated core files, controllers, classes, basic view files (CSS, JS, TPLs for admin and frontend sections), translation files (es, en), AJAX handler structure, and SQL (install/uninstall).

- Module name: mlthemebuilder
- Author: Byron Briones (bbrion.es)
- PHP code in English, user-facing text primarily in Spanish.
- Placeholder for module logo.png.
- Basic ObjectModels for Sections, Services, Brands, and Settings.
- Admin controller with AJAX methods for managing these entities.
- Frontend templates for rendering sections.
- Initial README.md.